### PR TITLE
Fix chat profile photos showing wrong user's picture

### DIFF
--- a/270202-test/270202c - Clutches.html
+++ b/270202-test/270202c - Clutches.html
@@ -56,7 +56,7 @@
     <form id="quiz-form" class="exam-form">
 
    <div class="question">
-        <p><strong>1. A clutch assembly is located between which two major vehicle components when the vehicle is equipped with a manual transmission or transaxle?</strong></p>
+        <p><strong>A clutch assembly is located between which two major vehicle components when the vehicle is equipped with a manual transmission or transaxle?</strong></p>
         <label><input type="radio" name="q1" value="a"> Engine crankshaft and rear differential</label>
         <label><input type="radio" name="q1" value="b"> Output shaft and drive wheels</label>
         <label><input type="radio" name="q1" value="c"> Engine flywheel and transmission input shaft</label>
@@ -64,7 +64,7 @@
       </div>
 
       <div class="question">
-        <p><strong>2. What is the primary purpose of the clutch assembly, allowing the engine to remain running when the vehicle is stopped and the transmission is not in neutral?</strong></p>
+        <p><strong>What is the primary purpose of the clutch assembly, allowing the engine to remain running when the vehicle is stopped and the transmission is not in neutral?</strong></p>
         <label><input type="radio" name="q2" value="a"> To increase output torque smoothly during acceleration.</label>
         <label><input type="radio" name="q2" value="b"> To prevent the transmission from exceeding engine RPM.</label>
         <label><input type="radio" name="q2" value="c"> To allow the engine to operate without putting the transmission in neutral.</label>
@@ -72,7 +72,7 @@
       </div>
 
       <div class="question">
-        <p><strong>3. In a friction clutch, the clamping force is typically provided by a spring or springs. This force may also be assisted by what secondary force, particularly in certain high-speed designs?</strong></p>
+        <p><strong>In a friction clutch, the clamping force is typically provided by a spring or springs. This force may also be assisted by what secondary force, particularly in certain high-speed designs?</strong></p>
         <label><input type="radio" name="q3" value="a"> Torsional force</label>
         <label><input type="radio" name="q3" value="b"> Axial thrust</label>
         <label><input type="radio" name="q3" value="c"> Centrifugal force</label>
@@ -80,7 +80,7 @@
       </div>
 
       <div class="question">
-        <p><strong>4. What is the functional state of the clutch when the clutch pedal is resting in the up position?</strong></p>
+        <p><strong>What is the functional state of the clutch when the clutch pedal is resting in the up position?</strong></p>
         <label><input type="radio" name="q4" value="a"> Disengaged, with no power flow.</label>
         <label><input type="radio" name="q4" value="b"> Freewheeling, allowing gear shifting.</label>
         <label><input type="radio" name="q4" value="c"> Engaged, allowing power flow to the transmission.</label>
@@ -88,7 +88,7 @@
       </div>
 
       <div class="question">
-        <p><strong>5. When a push-type clutch is fully engaged at highway speeds, what is the maximum amount of slippage typically observed between the clutch disc and the flywheel/pressure plate assembly?</strong></p>
+        <p><strong>When a push-type clutch is fully engaged at highway speeds, what is the maximum amount of slippage typically observed between the clutch disc and the flywheel/pressure plate assembly?</strong></p>
         <label><input type="radio" name="q5" value="a"> No slippage (0%)</label>
         <label><input type="radio" name="q5" value="b"> Typically no more than 2%</label>
         <label><input type="radio" name="q5" value="c"> Approximately 5%</label>
@@ -96,7 +96,7 @@
       </div>
 
       <div class="question">
-        <p><strong>6. Which type of clutch, classified by release bearing application, is most common in the heavy truck and equipment industry?</strong></p>
+        <p><strong>Which type of clutch, classified by release bearing application, is most common in the heavy truck and equipment industry?</strong></p>
         <label><input type="radio" name="q6" value="a"> Push-type</label>
         <label><input type="radio" name="q6" value="b"> Diaphragm spring type</label>
         <label><input type="radio" name="q6" value="c"> Pull-type</label>
@@ -104,7 +104,7 @@
       </div>
 
       <div class="question">
-        <p><strong>7. When the operator steps on the clutch pedal, the push-type release bearing moves inward, causing the release levers to pivot. In which direction do the release levers move the pressure plate?</strong></p>
+        <p><strong>When the operator steps on the clutch pedal, the push-type release bearing moves inward, causing the release levers to pivot. In which direction do the release levers move the pressure plate?</strong></p>
         <label><input type="radio" name="q7" value="a"> Away from the flywheel</label>
         <label><input type="radio" name="q7" value="b"> Toward the flywheel</label>
         <label><input type="radio" name="q7" value="c"> In the same direction as the disc</label>
@@ -112,7 +112,7 @@
       </div>
 
       <div class="question">
-        <p><strong>8. In a pull-type clutch assembly, when the release bearing assembly is moved away from the flywheel, what is the immediate action this takes on the inner ends of the release levers?</strong></p>
+        <p><strong>In a pull-type clutch assembly, when the release bearing assembly is moved away from the flywheel, what is the immediate action this takes on the inner ends of the release levers?</strong></p>
         <label><input type="radio" name="q8" value="a"> Pushes them toward the flywheel.</label>
         <label><input type="radio" name="q8" value="b"> Pulls them away from the flywheel.</label>
         <label><input type="radio" name="q8" value="c"> Locks them to the clutch cover.</label>
@@ -120,7 +120,7 @@
       </div>
 
       <div class="question">
-        <p><strong>9. What is the specific function of the torsional springs located within the hub of a spring-dampened clutch disc?</strong></p>
+        <p><strong>What is the specific function of the torsional springs located within the hub of a spring-dampened clutch disc?</strong></p>
         <label><input type="radio" name="q9" value="a"> To hold the clutch facings against the web.</label>
         <label><input type="radio" name="q9" value="b"> To adjust the clutch pedal free play.</label>
         <label><input type="radio" name="q9" value="c"> To absorb and dampen torque and engine power pulses.</label>
@@ -128,7 +128,7 @@
       </div>
 
       <div class="question">
-        <p><strong>10. Which spring component, constructed as a segmented, curved web of thin spring steel, provides cushioning during clutch application to ensure smooth engagement?</strong></p>
+        <p><strong>Which spring component, constructed as a segmented, curved web of thin spring steel, provides cushioning during clutch application to ensure smooth engagement?</strong></p>
         <label><input type="radio" name="q10" value="a"> Torsional Load Spring</label>
         <label><input type="radio" name="q10" value="b"> Belleville Spring</label>
         <label><input type="radio" name="q10" value="c"> Marcel Spring</label>
@@ -136,7 +136,7 @@
       </div>
 
       <div class="question">
-        <p><strong>11. The Torque Rating of a clutch assembly is defined as its ability to transmit torque. This rating is influenced by all of the following factors EXCEPT:</strong></p>
+        <p><strong>The Torque Rating of a clutch assembly is defined as its ability to transmit torque. This rating is influenced by all of the following factors EXCEPT:</strong></p>
         <label><input type="radio" name="q11" value="a"> The applied force of the pressure plate springs.</label>
         <label><input type="radio" name="q11" value="b"> The coefficient of friction of the facing materials.</label>
         <label><input type="radio" name="q11" value="c"> The physical size of the clutch disc.</label>
@@ -144,7 +144,7 @@
       </div>
 
       <div class="question">
-        <p><strong>12. Which type of clutch spring design is also called a diaphragm spring?</strong></p>
+        <p><strong>Which type of clutch spring design is also called a diaphragm spring?</strong></p>
         <label><input type="radio" name="q12" value="a"> Perpendicular Coil Springs</label>
         <label><input type="radio" name="q12" value="b"> Angled Coil Springs</label>
         <label><input type="radio" name="q12" value="c"> Torsional Spring</label>
@@ -152,7 +152,7 @@
       </div>
 
       <div class="question">
-        <p><strong>13. What is the primary purpose of the small ball or roller bearing located in the bore of the flywheel or crankshaft?</strong></p>
+        <p><strong>What is the primary purpose of the small ball or roller bearing located in the bore of the flywheel or crankshaft?</strong></p>
         <label><input type="radio" name="q13" value="a"> To carry the axial load of the transmission input shaft.</label>
         <label><input type="radio" name="q13" value="b"> To reduce rotational friction when the clutch is engaged.</label>
         <label><input type="radio" name="q13" value="c"> To pilot (guide and align) the transmission input shaft.</label>
@@ -160,7 +160,7 @@
       </div>
 
       <div class="question">
-        <p><strong>14. According to the source, why must a flywheel that includes engine balancing weights be carefully handled?</strong></p>
+        <p><strong>According to the source, why must a flywheel that includes engine balancing weights be carefully handled?</strong></p>
         <label><input type="radio" name="q14" value="a"> Because the internal ring gear may fail if dropped.</label>
         <label><input type="radio" name="q14" value="b"> Because a flywheel from an externally balanced engine must not be installed onto an internally balanced engine (and vice versa).</label>
         <label><input type="radio" name="q14" value="c"> Because the dowel pins must never be removed from the friction surface.</label>
@@ -168,7 +168,7 @@
       </div>
 
       <div class="question">
-        <p><strong>15. Flywheels are typically constructed from what material due to its weight, low cost, and friction qualities?</strong></p>
+        <p><strong>Flywheels are typically constructed from what material due to its weight, low cost, and friction qualities?</strong></p>
         <label><input type="radio" name="q15" value="a"> Aluminum alloy</label>
         <label><input type="radio" name="q15" value="b"> Stamped steel</label>
         <label><input type="radio" name="q15" value="c"> Cast iron</label>
@@ -176,7 +176,7 @@
       </div>
 
       <div class="question">
-        <p><strong>16. Which style of flywheel combines two surfaces, one for the clutch cover and one friction surface for the clutch disc, and is suitable for both single and double disc clutch assemblies?</strong></p>
+        <p><strong>Which style of flywheel combines two surfaces, one for the clutch cover and one friction surface for the clutch disc, and is suitable for both single and double disc clutch assemblies?</strong></p>
         <label><input type="radio" name="q16" value="a"> Stepped</label>
         <label><input type="radio" name="q16" value="b"> Countersunk</label>
         <label><input type="radio" name="q16" value="c"> Flat</label>
@@ -184,7 +184,7 @@
       </div>
 
       <div class="question">
-        <p><strong>17. What is the primary functional advantage of a stamped steel clutch cover compared to a heavy cast iron cover?</strong></p>
+        <p><strong>What is the primary functional advantage of a stamped steel clutch cover compared to a heavy cast iron cover?</strong></p>
         <label><input type="radio" name="q17" value="a"> Stamped steel absorbs more heat during clutch operation.</label>
         <label><input type="radio" name="q17" value="b"> Stamped steel provides a more rigid structure under increased torque loads.</label>
         <label><input type="radio" name="q17" value="c"> Stamped steel is lighter and allows higher engine speeds to develop.</label>
@@ -192,7 +192,7 @@
       </div>
 
       <div class="question">
-        <p><strong>18. In heavy-duty applications, the clutch cover may be made of cast iron because this material provides which functional advantage?</strong></p>
+        <p><strong>In heavy-duty applications, the clutch cover may be made of cast iron because this material provides which functional advantage?</strong></p>
         <label><input type="radio" name="q18" value="a"> Lighter weight for faster acceleration.</label>
         <label><input type="radio" name="q18" value="b"> A more rigid structure under increased torque loads and better heat absorption.</label>
         <label><input type="radio" name="q18" value="c"> Increased friction coefficient for the pressure plate.</label>
@@ -200,7 +200,7 @@
       </div>
 
       <div class="question">
-        <p><strong>19. Pressure plate assemblies are considered drive members of the clutch assembly along with which other component?</strong></p>
+        <p><strong>Pressure plate assemblies are considered drive members of the clutch assembly along with which other component?</strong></p>
         <label><input type="radio" name="q19" value="a"> Clutch disc (driven member)</label>
         <label><input type="radio" name="q19" value="b"> Clutch cover</label>
         <label><input type="radio" name="q19" value="c"> Flywheel</label>
@@ -208,7 +208,7 @@
       </div>
 
       <div class="question">
-        <p><strong>20. Which type of pressure plate spring arrangement is typically heavier than a diaphragm clutch for the same application and uses 6 to 12 coil springs standing at 90° to the pressure plate?</strong></p>
+        <p><strong>Which type of pressure plate spring arrangement is typically heavier than a diaphragm clutch for the same application and uses 6 to 12 coil springs standing at 90° to the pressure plate?</strong></p>
         <label><input type="radio" name="q20" value="a"> Angled Coil Springs</label>
         <label><input type="radio" name="q20" value="b"> Belleville (Diaphragm) Spring</label>
         <label><input type="radio" name="q20" value="c"> Perpendicular Coil Springs</label>
@@ -216,7 +216,7 @@
       </div>
 
       <div class="question">
-        <p><strong>21. Some coil spring type clutches are classified as semi-centrifugal due to the addition of centrifugal weights. What is the purpose of these weights?</strong></p>
+        <p><strong>Some coil spring type clutches are classified as semi-centrifugal due to the addition of centrifugal weights. What is the purpose of these weights?</strong></p>
         <label><input type="radio" name="q21" value="a"> To allow the clutch disc to freewheel upon disengagement.</label>
         <label><input type="radio" name="q21" value="b"> To reduce clutch slippage by increasing the clamping force on the pressure plate at high engine rpm.</label>
         <label><input type="radio" name="q21" value="c"> To provide sufficient throwout bearing clearance during engagement.</label>
@@ -224,7 +224,7 @@
       </div>
 
       <div class="question">
-        <p><strong>22. A rigid clutch disc is typically used in applications where:</strong></p>
+        <p><strong>A rigid clutch disc is typically used in applications where:</strong></p>
         <label><input type="radio" name="q22" value="a"> High torque and low speed are required.</label>
         <label><input type="radio" name="q22" value="b"> A limited amount of engagement and disengagement occurs.</label>
         <label><input type="radio" name="q22" value="c"> Maximum cushioning of clutch application is needed.</label>
@@ -232,7 +232,7 @@
       </div>
 
       <div class="question">
-        <p><strong>23. Dampened clutch discs utilize torsional springs in the hub. Under what conditions will these springs compress until the hub flange contacts the stop pins?</strong></p>
+        <p><strong>Dampened clutch discs utilize torsional springs in the hub. Under what conditions will these springs compress until the hub flange contacts the stop pins?</strong></p>
         <label><input type="radio" name="q23" value="a"> Under light torque loads.</label>
         <label><input type="radio" name="q23" value="b"> When the clutch is disengaged.</label>
         <label><input type="radio" name="q23" value="c"> Under high torque loads.</label>
@@ -240,7 +240,7 @@
       </div>
 
       <div class="question">
-        <p><strong>24. What is the function of the holes usually drilled through the rivets used in mounting organic clutch facings?</strong></p>
+        <p><strong>What is the function of the holes usually drilled through the rivets used in mounting organic clutch facings?</strong></p>
         <label><input type="radio" name="q24" value="a"> To secure the rivets to the segmented steel web.</label>
         <label><input type="radio" name="q24" value="b"> To act as a wear indicator.</label>
         <label><input type="radio" name="q24" value="c"> To act as a vacuum break.</label>
@@ -248,7 +248,7 @@
       </div>
 
       <div class="question">
-        <p><strong>25. Organic clutch disc linings are referred to as non-asbestos organic (NAO). Which materials are currently mixed into these linings to provide the correct combination of friction, strength, and durability?</strong></p>
+        <p><strong>Organic clutch disc linings are referred to as non-asbestos organic (NAO). Which materials are currently mixed into these linings to provide the correct combination of friction, strength, and durability?</strong></p>
         <label><input type="radio" name="q25" value="a"> Metallic and lead compounds</label>
         <label><input type="radio" name="q25" value="b"> Carbon and silica compounds</label>
         <label><input type="radio" name="q25" value="c"> Fibreglass, Aramid, and Kevlar</label>
@@ -256,7 +256,7 @@
       </div>
 
       <div class="question">
-        <p><strong>26. Which type of clutch disc lining provides very good resistance to slipping, a long service life, and is commonly used in heavy-duty truck applications, despite causing premature wear on the pressure plate and flywheel?</strong></p>
+        <p><strong>Which type of clutch disc lining provides very good resistance to slipping, a long service life, and is commonly used in heavy-duty truck applications, despite causing premature wear on the pressure plate and flywheel?</strong></p>
         <label><input type="radio" name="q26" value="a"> Organic linings</label>
         <label><input type="radio" name="q26" value="b"> Semi-metallic linings</label>
         <label><input type="radio" name="q26" value="c"> Ceramic linings (ceramic button)</label>
@@ -264,7 +264,7 @@
       </div>
 
       <div class="question">
-        <p><strong>27. The radial grooves cut into clutch facings serve several functions, including cooling the clutch disc and providing a vacuum break. They also increase the unit pressure on the lining by achieving what physical result?</strong></p>
+        <p><strong>The radial grooves cut into clutch facings serve several functions, including cooling the clutch disc and providing a vacuum break. They also increase the unit pressure on the lining by achieving what physical result?</strong></p>
         <label><input type="radio" name="q27" value="a"> Increasing the total surface area of contact.</label>
         <label><input type="radio" name="q27" value="b"> Reducing the surface area on which the clamping force is applied.</label>
         <label><input type="radio" name="q27" value="c"> Reducing the coefficient of friction.</label>
@@ -272,7 +272,7 @@
       </div>
 
       <div class="question">
-        <p><strong>28. When two clutch discs are used in a high-torque application, what component is required between the two discs to provide the necessary friction surfaces that do not contact the flywheel or pressure plate?</strong></p>
+        <p><strong>When two clutch discs are used in a high-torque application, what component is required between the two discs to provide the necessary friction surfaces that do not contact the flywheel or pressure plate?</strong></p>
         <label><input type="radio" name="q28" value="a"> Slave cylinder</label>
         <label><input type="radio" name="q28" value="b"> Intermediate plate</label>
         <label><input type="radio" name="q28" value="c"> Clutch cover</label>
@@ -280,7 +280,7 @@
       </div>
 
       <div class="question">
-        <p><strong>29. An intermediate plate in a double disc clutch must be able to move slightly during the engagement and disengagement process. What happens if this plate is fastened too tightly?</strong></p>
+        <p><strong>An intermediate plate in a double disc clutch must be able to move slightly during the engagement and disengagement process. What happens if this plate is fastened too tightly?</strong></p>
         <label><input type="radio" name="q29" value="a"> The clutch brake will engage prematurely.</label>
         <label><input type="radio" name="q29" value="b"> The driven member will be locked to the drive member.</label>
         <label><input type="radio" name="q29" value="c"> One or both clutch discs will remain in contact with a friction surface on disengagement.</label>
@@ -288,7 +288,7 @@
       </div>
 
       <div class="question">
-        <p><strong>30. In heavy-duty dual mass flywheels, if any part of the complex unit fails, what specific replacement procedure is mandatory?</strong></p>
+        <p><strong>In heavy-duty dual mass flywheels, if any part of the complex unit fails, what specific replacement procedure is mandatory?</strong></p>
         <label><input type="radio" name="q30" value="a"> Only the failed component (primary or secondary flywheel) must be replaced.</label>
         <label><input type="radio" name="q30" value="b"> The secondary flywheel and clutch disc must be replaced as a set.</label>
         <label><input type="radio" name="q30" value="c"> The entire flywheel must be replaced.</label>
@@ -296,7 +296,7 @@
       </div>
 
       <div class="question">
-        <p><strong>31. In terms of function, what type of load must the clutch release bearing withstand?</strong></p>
+        <p><strong>In terms of function, what type of load must the clutch release bearing withstand?</strong></p>
         <label><input type="radio" name="q31" value="a"> Radial load</label>
         <label><input type="radio" name="q31" value="b"> Axial load (thrust type)</label>
         <label><input type="radio" name="q31" value="c"> Torsional load</label>
@@ -304,7 +304,7 @@
       </div>
 
       <div class="question">
-        <p><strong>32. What is the classification given to release bearings used in heavy-duty applications, based on the fact that they rotate only during the engagement and disengagement process?</strong></p>
+        <p><strong>What is the classification given to release bearings used in heavy-duty applications, based on the fact that they rotate only during the engagement and disengagement process?</strong></p>
         <label><input type="radio" name="q32" value="a"> Roller bearings</label>
         <label><input type="radio" name="q32" value="b"> Full-time spin bearings</label>
         <label><input type="radio" name="q32" value="c"> Intermittent use bearings</label>
@@ -312,7 +312,7 @@
       </div>
 
       <div class="question">
-        <p><strong>33. What is the functional role of the clutch release fork in a standard push-type mechanism?</strong></p>
+        <p><strong>What is the functional role of the clutch release fork in a standard push-type mechanism?</strong></p>
         <label><input type="radio" name="q33" value="a"> It pivots on a clutch cover pivot bolt to engage the clutch.</label>
         <label><input type="radio" name="q33" value="b"> It transmits engine noise and vibration back to the driver.</label>
         <label><input type="radio" name="q33" value="c"> It pivots on the ball stud in the clutch housing and pushes the release bearing forward to act on the release levers.</label>
@@ -320,7 +320,7 @@
       </div>
 
       <div class="question">
-        <p><strong>34. When an operator is shifting a heavy truck from neutral to first or reverse gear, what is the primary purpose of a clutch brake?</strong></p>
+        <p><strong>When an operator is shifting a heavy truck from neutral to first or reverse gear, what is the primary purpose of a clutch brake?</strong></p>
         <label><input type="radio" name="q34" value="a"> To absorb power pulses from the engine.</label>
         <label><input type="radio" name="q34" value="b"> To provide maximum heat dissipation.</label>
         <label><input type="radio" name="q34" value="c"> To slow the rotation of the clutch disc and transmission input shaft to prevent gear teeth clash.</label>
@@ -328,7 +328,7 @@
       </div>
 
       <div class="question">
-        <p><strong>35. A Torque-Limiting Clutch Brake is designed to slip internally above a pre-determined torque load. What failure does this action prevent, thus increasing service life?</strong></p>
+        <p><strong>A Torque-Limiting Clutch Brake is designed to slip internally above a pre-determined torque load. What failure does this action prevent, thus increasing service life?</strong></p>
         <label><input type="radio" name="q35" value="a"> Failure of the transmission input shaft splines.</label>
         <label><input type="radio" name="q35" value="b"> Breakage of the tangs on the clutch brake.</label>
         <label><input type="radio" name="q35" value="c"> Slippage of the clutch disc at high RPM.</label>
@@ -336,7 +336,7 @@
       </div>
 
       <div class="question">
-        <p><strong>36. What advantage does a two-piece clutch brake offer over a conventional design?</strong></p>
+        <p><strong>What advantage does a two-piece clutch brake offer over a conventional design?</strong></p>
         <label><input type="radio" name="q36" value="a"> It requires less lubricant.</label>
         <label><input type="radio" name="q36" value="b"> It operates cooler and can be replaced without removing the transmission.</label>
         <label><input type="radio" name="q36" value="c"> It provides a higher torque capacity.</label>
@@ -344,7 +344,7 @@
       </div>
 
       <div class="question">
-        <p><strong>37. The pilot bearing operates only as a bearing when the clutch is disengaged. At this time, what are the relative speeds of the crankshaft and the transmission input shaft?</strong></p>
+        <p><strong>The pilot bearing operates only as a bearing when the clutch is disengaged. At this time, what are the relative speeds of the crankshaft and the transmission input shaft?</strong></p>
         <label><input type="radio" name="q37" value="a"> Both shafts turn at the same speed.</label>
         <label><input type="radio" name="q37" value="b"> Both shafts remain stationary.</label>
         <label><input type="radio" name="q37" value="c"> The shafts are turning at different speeds.</label>
@@ -352,7 +352,7 @@
       </div>
 
       <div class="question">
-        <p><strong>38. The clutch housing (bell housing) may be made of cast iron, particularly for which type of application?</strong></p>
+        <p><strong>The clutch housing (bell housing) may be made of cast iron, particularly for which type of application?</strong></p>
         <label><input type="radio" name="q38" value="a"> Front wheel drive vehicles</label>
         <label><input type="radio" name="q38" value="b"> Light-duty vehicles</label>
         <label><input type="radio" name="q38" value="c"> Heavy-duty use</label>
@@ -360,7 +360,7 @@
       </div>
 
       <div class="question">
-        <p><strong>39. What critical function do the dowel pins or bushings in the back of the engine block serve when mating with the forward face of the clutch housing?</strong></p>
+        <p><strong>What critical function do the dowel pins or bushings in the back of the engine block serve when mating with the forward face of the clutch housing?</strong></p>
         <label><input type="radio" name="q39" value="a"> They allow for the mounting of the clutch cover.</label>
         <label><input type="radio" name="q39" value="b"> They ensure the clutch housing is properly aligned with the engine.</label>
         <label><input type="radio" name="q39" value="c"> They provide the mounting point for the clutch slave cylinder.</label>
@@ -368,7 +368,7 @@
       </div>
 
       <div class="question">
-        <p><strong>40. When supplying replacement clutch components, what critical piece of information, aside from the vehicle identification, should the parts technician obtain?</strong></p>
+        <p><strong>When supplying replacement clutch components, what critical piece of information, aside from the vehicle identification, should the parts technician obtain?</strong></p>
         <label><input type="radio" name="q40" value="a"> The length of the clutch release fork.</label>
         <label><input type="radio" name="q40" value="b"> The total weight of the clutch assembly.</label>
         <label><input type="radio" name="q40" value="c"> The size (diameter) of the clutch disc.</label>
@@ -376,7 +376,7 @@
       </div>
 
       <div class="question">
-        <p><strong>41. Why is it standard advice to suggest and provide a release bearing and pilot bearing/bushing during any clutch service job?</strong></p>
+        <p><strong>Why is it standard advice to suggest and provide a release bearing and pilot bearing/bushing during any clutch service job?</strong></p>
         <label><input type="radio" name="q41" value="a"> Because these parts must be matched to the specific friction material used.</label>
         <label><input type="radio" name="q41" value="b"> Because they are included in every OEM individual parts package.</label>
         <label><input type="radio" name="q41" value="c"> Because the cost of these parts is minimal compared to the labour charges required to replace them later.</label>
@@ -384,7 +384,7 @@
       </div>
 
       <div class="question">
-        <p><strong>42. What is the primary functional difference between a Dampened (Flexible) Clutch Disc and a Rigid Clutch Disc regarding vibration?</strong></p>
+        <p><strong>What is the primary functional difference between a Dampened (Flexible) Clutch Disc and a Rigid Clutch Disc regarding vibration?</strong></p>
         <label><input type="radio" name="q42" value="a"> Rigid discs handle torque pulses better than dampened discs.</label>
         <label><input type="radio" name="q42" value="b"> Dampened discs are required for high RPM applications, while rigid discs are for low RPM.</label>
         <label><input type="radio" name="q42" value="c"> Dampened discs reduce torsional vibration, extending drivetrain component life.</label>
@@ -392,7 +392,7 @@
       </div>
 
       <div class="question">
-        <p><strong>43. Which type of actuation system is most susceptible to transmitting engine noise and vibration back to the driver, requiring frequent adjustment?</strong></p>
+        <p><strong>Which type of actuation system is most susceptible to transmitting engine noise and vibration back to the driver, requiring frequent adjustment?</strong></p>
         <label><input type="radio" name="q43" value="a"> Hydraulic system</label>
         <label><input type="radio" name="q43" value="b"> Cable system</label>
         <label><input type="radio" name="q43" value="c"> Mechanical linkage system</label>
@@ -400,7 +400,7 @@
       </div>
 
       <div class="question">
-        <p><strong>44. A hydraulic clutch system uses a pushrod attached to the pedal arm that applies force to a single reservoir hydraulic master cylinder. This pressure is transferred via hydraulic lines to which other component near the clutch?</strong></p>
+        <p><strong>A hydraulic clutch system uses a pushrod attached to the pedal arm that applies force to a single reservoir hydraulic master cylinder. This pressure is transferred via hydraulic lines to which other component near the clutch?</strong></p>
         <label><input type="radio" name="q44" value="a"> Clutch housing</label>
         <label><input type="radio" name="q44" value="b"> Slave cylinder</label>
         <label><input type="radio" name="q44" value="c"> Release bearing guide</label>
@@ -408,7 +408,7 @@
       </div>
 
       <div class="question">
-        <p><strong>45. In a compound failure scenario where the Pilot Bearing has failed, which related components should a parts technician also suggest for sales, according to Table 3?</strong></p>
+        <p><strong>In a compound failure scenario where the Pilot Bearing has failed, which related components should a parts technician also suggest for sales, according to Table 3?</strong></p>
         <label><input type="radio" name="q45" value="a"> Clutch fork boot and clutch fork pivot</label>
         <label><input type="radio" name="q45" value="b"> Only the transmission input shaft bearing retainer.</label>
         <label><input type="radio" name="q45" value="c"> Clutch assembly</label>
@@ -416,7 +416,7 @@
       </div>
 
       <div class="question">
-        <p><strong>46. When matching a new or rebuilt pressure plate assembly to an old unit, what critical design feature must a technician check?</strong></p>
+        <p><strong>When matching a new or rebuilt pressure plate assembly to an old unit, what critical design feature must a technician check?</strong></p>
         <label><input type="radio" name="q46" value="a"> The thickness of the intermediate plate.</label>
         <label><input type="radio" name="q46" value="b"> The coefficient of friction (must be ceramic).</label>
         <label><input type="radio" name="q46" value="c"> Pressure plate assembly design (diaphragm, coil spring, etc.).</label>
@@ -424,7 +424,7 @@
       </div>
 
       <div class="question">
-        <p><strong>47. What operational condition is characterized by the clutch disc remaining stationary or turning slowly, while the flywheel and clutch cover/pressure plate assembly rotate at engine speed?</strong></p>
+        <p><strong>What operational condition is characterized by the clutch disc remaining stationary or turning slowly, while the flywheel and clutch cover/pressure plate assembly rotate at engine speed?</strong></p>
         <label><input type="radio" name="q47" value="a"> Clutch Engaged</label>
         <label><input type="radio" name="q47" value="b"> Freewheeling</label>
         <label><input type="radio" name="q47" value="c"> Clutch Disengaged</label>
@@ -432,7 +432,7 @@
       </div>
 
       <div class="question">
-        <p><strong>48. When the clutch is engaged, the flywheel, the pressure plate assembly, and the clutch disc rotate together. What is the relationship between their speed and direction?</strong></p>
+        <p><strong>When the clutch is engaged, the flywheel, the pressure plate assembly, and the clutch disc rotate together. What is the relationship between their speed and direction?</strong></p>
         <label><input type="radio" name="q48" value="a"> They rotate in opposite directions at the same speed.</label>
         <label><input type="radio" name="q48" value="b"> They rotate in the same direction at slightly different speeds.</label>
         <label><input type="radio" name="q48" value="c"> They rotate together as a unit in the same direction and at the same speed.</label>
@@ -440,7 +440,7 @@
       </div>
 
       <div class="question">
-        <p><strong>49. A Multi-disc clutch assembly (e.g., using an intermediate plate) provides which dual performance advantage over a single-disc clutch?</strong></p>
+        <p><strong>A Multi-disc clutch assembly (e.g., using an intermediate plate) provides which dual performance advantage over a single-disc clutch?</strong></p>
         <label><input type="radio" name="q49" value="a"> Handle more torque and handle more heat.</label>
         <label><input type="radio" name="q49" value="b"> Reduced weight and reduced maintenance costs.</label>
         <label><input type="radio" name="q49" value="c"> Increased slip resistance and smoother engagement.</label>
@@ -448,7 +448,7 @@
       </div>
 
       <div class="question">
-        <p><strong>50. Based on the concept of friction clutches, the disc (clutch assembly driven member) is splined to the transmission input shaft, allowing it to move freely along the shaft. What component holds the disc in place axially?</strong></p>
+        <p><strong>Based on the concept of friction clutches, the disc (clutch assembly driven member) is splined to the transmission input shaft, allowing it to move freely along the shaft. What component holds the disc in place axially?</strong></p>
         <label><input type="radio" name="q50" value="a"> The pilot bushing/bearing.</label>
         <label><input type="radio" name="q50" value="b"> The clutch release fork.</label>
         <label><input type="radio" name="q50" value="c"> The release bearing retainer.</label>

--- a/270202-test/270202d - Light-Duty Manual Transmissions.html
+++ b/270202-test/270202d - Light-Duty Manual Transmissions.html
@@ -74,7 +74,7 @@
       <form id="quiz-form" class="exam-form">
 
       <div class="question">
-        <p><strong>1. What are the three main purposes of a manual transmission or transaxle?</strong></p>
+        <p><strong>What are the three main purposes of a manual transmission or transaxle?</strong></p>
         <label><input type="radio" name="q1" value="a"> To multiply torque, increase horsepower, and provide a direct drive.</label>
         <label><input type="radio" name="q1" value="b"> To increase speed, decrease torque, and provide forward motion.</label>
         <label><input type="radio" name="q1" value="c"> To provide variable torque and speed, to provide a reverse, and to provide a neutral.</label>
@@ -82,7 +82,7 @@
       </div>
 
 <div class="question">
-        <p><strong>2. Transaxles, compared to traditional transmissions, incorporate which additional components into their assembly?</strong></p>
+        <p><strong>Transaxles, compared to traditional transmissions, incorporate which additional components into their assembly?</strong></p>
         <label><input type="radio" name="q2" value="a"> Clutch housing, shift rails, and reverse idler gear.</label>
         <label><input type="radio" name="q2" value="b"> Input, output, and countershaft assemblies.</label>
         <label><input type="radio" name="q2" value="c"> Final drive, differential gearing, and drive axle connections.</label>
@@ -90,7 +90,7 @@
       </div>
 
 <div class="question">
-        <p><strong>3. The transaxle assembly is fundamentally a combination of a transmission and which other assembly?</strong></p>
+        <p><strong>The transaxle assembly is fundamentally a combination of a transmission and which other assembly?</strong></p>
         <label><input type="radio" name="q3" value="a"> Planetary gear set (overdrive unit)</label>
         <label><input type="radio" name="q3" value="b"> Main drive pinion (input shaft)</label>
         <label><input type="radio" name="q3" value="c"> Axle assembly (final drive and differential unit)</label>
@@ -98,7 +98,7 @@
       </div>
 
 <div class="question">
-        <p><strong>4. A major difference between manual transmissions and transaxles is the number of main internal shafts. How many shafts do transaxles typically have?</strong></p>
+        <p><strong>A major difference between manual transmissions and transaxles is the number of main internal shafts. How many shafts do transaxles typically have?</strong></p>
         <label><input type="radio" name="q4" value="a"> Four shafts (input, output, reverse idler, and countershaft cluster)</label>
         <label><input type="radio" name="q4" value="b"> Three shafts (input, output, and reverse idler) with cluster gears on the input shaft.</label>
         <label><input type="radio" name="q4" value="c"> Two shafts (input and output) with a differential drive.</label>
@@ -106,7 +106,7 @@
       </div>
 
 <div class="question">
-        <p><strong>5. What is the most common configuration for transaxles found in the majority of modern front-wheel drive cars?</strong></p>
+        <p><strong>What is the most common configuration for transaxles found in the majority of modern front-wheel drive cars?</strong></p>
         <label><input type="radio" name="q5" value="a"> Longitudinal engine and transaxle assembly.</label>
         <label><input type="radio" name="q5" value="b"> Transverse engine and transaxle assembly.</label>
         <label><input type="radio" name="q5" value="c"> Rear-wheel drive configuration with a rear axle housing.</label>
@@ -114,7 +114,7 @@
       </div>
 
 <div class="question">
-        <p><strong>6. What is the primary functional difference between all current automotive manual transmissions/transaxles and older sliding gear designs?</strong></p>
+        <p><strong>What is the primary functional difference between all current automotive manual transmissions/transaxles and older sliding gear designs?</strong></p>
         <label><input type="radio" name="q6" value="a"> All modern units use engine oil for lubrication.</label>
         <label><input type="radio" name="q6" value="b"> Modern units have three shafts instead of four.</label>
         <label><input type="radio" name="q6" value="c"> Modern units are of synchromesh design, meaning the gears are in constant mesh.</label>
@@ -122,7 +122,7 @@
       </div>
 
 <div class="question">
-        <p><strong>7. A power transmission assembly has a calculated gear ratio of 0.722 to 1. This ratio indicates that the gear (speed) is operating in which specific range?</strong></p>
+        <p><strong>A power transmission assembly has a calculated gear ratio of 0.722 to 1. This ratio indicates that the gear (speed) is operating in which specific range?</strong></p>
         <label><input type="radio" name="q7" value="a"> First gear reduction</label>
         <label><input type="radio" name="q7" value="b"> Reverse reduction</label>
         <label><input type="radio" name="q7" value="c"> Overdrive (5th gear)</label>
@@ -130,7 +130,7 @@
       </div>
 
 <div class="question">
-        <p><strong>8. In a five-speed manual transmission, what component must the 3rd–4th synchronizer sleeve lock to the output shaft to achieve 4th speed (Direct Drive)?</strong></p>
+        <p><strong>In a five-speed manual transmission, what component must the 3rd–4th synchronizer sleeve lock to the output shaft to achieve 4th speed (Direct Drive)?</strong></p>
         <label><input type="radio" name="q8" value="a"> The 4th cluster gear</label>
         <label><input type="radio" name="q8" value="b"> The 4th output gear</label>
         <label><input type="radio" name="q8" value="c"> The input shaft</label>
@@ -138,7 +138,7 @@
       </div>
 
 <div class="question">
-        <p><strong>9. Which component in a transmission is typically called the clutch shaft, pilot shaft, or main drive pinion?</strong></p>
+        <p><strong>Which component in a transmission is typically called the clutch shaft, pilot shaft, or main drive pinion?</strong></p>
         <label><input type="radio" name="q9" value="a"> Output Shaft #41</label>
         <label><input type="radio" name="q9" value="b"> Countershaft #69</label>
         <label><input type="radio" name="q9" value="c"> Input Shaft #71</label>
@@ -146,7 +146,7 @@
       </div>
 
 <div class="question">
-        <p><strong>10. What is the function of the pilot bearing (either roller or bushing) located in the back of the input shaft?</strong></p>
+        <p><strong>What is the function of the pilot bearing (either roller or bushing) located in the back of the input shaft?</strong></p>
         <label><input type="radio" name="q10" value="a"> To transmit power from the clutch to the cluster gear.</label>
         <label><input type="radio" name="q10" value="b"> To support the output shaft snap rings.</label>
         <label><input type="radio" name="q10" value="c"> To support the output shaft (mainshaft or tailshaft).</label>
@@ -154,7 +154,7 @@
       </div>
 
 <div class="question">
-        <p><strong>11. What is the purpose of the thrust washers used in a manual transmission assembly?</strong></p>
+        <p><strong>What is the purpose of the thrust washers used in a manual transmission assembly?</strong></p>
         <label><input type="radio" name="q11" value="a"> To secure the reverse idler gear in the lower portion of the case.</label>
         <label><input type="radio" name="q11" value="b"> To take up end thrust and prevent excessive end play, providing a replaceable wear surface.</label>
         <label><input type="radio" name="q11" value="c"> To provide a friction surface for the detent system.</label>
@@ -162,7 +162,7 @@
       </div>
 
 <div class="question">
-        <p><strong>12. In a synchromesh transmission, the cluster shaft gear (#66) is also commonly referred to by what name?</strong></p>
+        <p><strong>In a synchromesh transmission, the cluster shaft gear (#66) is also commonly referred to by what name?</strong></p>
         <label><input type="radio" name="q12" value="a"> Main drive pinion</label>
         <label><input type="radio" name="q12" value="b"> Output gear</label>
         <label><input type="radio" name="q12" value="c"> Counter gear or countershaft gear</label>
@@ -170,7 +170,7 @@
       </div>
 
 <div class="question">
-        <p><strong>13. What is the typical construction characteristic of the cluster shaft gear in automotive and light-duty applications?</strong></p>
+        <p><strong>What is the typical construction characteristic of the cluster shaft gear in automotive and light-duty applications?</strong></p>
         <label><input type="radio" name="q13" value="a"> It consists of multiple independent gears keyed individually to the shaft.</label>
         <label><input type="radio" name="q13" value="b"> It is always supported entirely by ball bearings.</label>
         <label><input type="radio" name="q13" value="c"> It is often machined as one piece.</label>
@@ -178,7 +178,7 @@
       </div>
 
 <div class="question">
-        <p><strong>14. The reverse idler gear (#36) serves what singular function in the transmission power path?</strong></p>
+        <p><strong>The reverse idler gear (#36) serves what singular function in the transmission power path?</strong></p>
         <label><input type="radio" name="q14" value="a"> It allows the transaxle to shift into neutral.</label>
         <label><input type="radio" name="q14" value="b"> It converts rotary motion to linear motion.</label>
         <label><input type="radio" name="q14" value="c"> It causes a change in the mainshaft gear direction of rotation.</label>
@@ -186,7 +186,7 @@
       </div>
 
 <div class="question">
-        <p><strong>15. What are the two major categories of seals used to seal a manual transmission or transaxle?</strong></p>
+        <p><strong>What are the two major categories of seals used to seal a manual transmission or transaxle?</strong></p>
         <label><input type="radio" name="q15" value="a"> Press-fit and O-ring</label>
         <label><input type="radio" name="q15" value="b"> Static and dynamic</label>
         <label><input type="radio" name="q15" value="c"> Lip seals and gaskets</label>
@@ -194,7 +194,7 @@
       </div>
 
 <div class="question">
-        <p><strong>16. The front bearing retainer gasket is commonly made of paper and seals the surface between the bearing retainer and the transmission housing. How is this type of seal classified?</strong></p>
+        <p><strong>The front bearing retainer gasket is commonly made of paper and seals the surface between the bearing retainer and the transmission housing. How is this type of seal classified?</strong></p>
         <label><input type="radio" name="q16" value="a"> Dynamic seal (seals moving parts)</label>
         <label><input type="radio" name="q16" value="b"> Radial lip seal</label>
         <label><input type="radio" name="q16" value="c"> Static seal (seals stationary parts)</label>
@@ -202,7 +202,7 @@
       </div>
 
 <div class="question">
-        <p><strong>17. Which type of seal, such as the input shaft seal or the driveshaft slip yoke seal, is classified as a dynamic seal?</strong></p>
+        <p><strong>Which type of seal, such as the input shaft seal or the driveshaft slip yoke seal, is classified as a dynamic seal?</strong></p>
         <label><input type="radio" name="q17" value="a"> Cork gasket</label>
         <label><input type="radio" name="q17" value="b"> Paper gasket</label>
         <label><input type="radio" name="q17" value="c"> Radial lip seal (seals moving parts)</label>
@@ -210,7 +210,7 @@
       </div>
 
 <div class="question">
-        <p><strong>18. What is the explicit purpose of the synchronizer unit&#x27;s blocking ring?</strong></p>
+        <p><strong>What is the explicit purpose of the synchronizer unit&#x27;s blocking ring?</strong></p>
         <label><input type="radio" name="q18" value="a"> To transmit power to the output shaft during the shift.</label>
         <label><input type="radio" name="q18" value="b"> To lock the output gear to the synchronizer hub.</label>
         <label><input type="radio" name="q18" value="c"> To act as a brake shoe to bring the output gear to the speed of the output shaft.</label>
@@ -218,7 +218,7 @@
       </div>
 
 <div class="question">
-        <p><strong>19. Why does the source explicitly state that no power flow is ever transmitted through the blocking ring?</strong></p>
+        <p><strong>Why does the source explicitly state that no power flow is ever transmitted through the blocking ring?</strong></p>
         <label><input type="radio" name="q19" value="a"> Because it is made of brass, a non-ferrous metal.</label>
         <label><input type="radio" name="q19" value="b"> Its sole purpose is to equalize speed (act as a brake shoe).</label>
         <label><input type="radio" name="q19" value="c"> It is only engaged when the transmission is in neutral.</label>
@@ -226,7 +226,7 @@
       </div>
 
 <div class="question">
-        <p><strong>20. The inner surface of the blocking ring, which contacts the mating output gear, is cone-shaped and contains many small, sharp ridges. What is the function of these ridges?</strong></p>
+        <p><strong>The inner surface of the blocking ring, which contacts the mating output gear, is cone-shaped and contains many small, sharp ridges. What is the function of these ridges?</strong></p>
         <label><input type="radio" name="q20" value="a"> To align the ring with the three notches on the hub.</label>
         <label><input type="radio" name="q20" value="b"> To provide friction against the tapered surface of the gear to equalize speed.</label>
         <label><input type="radio" name="q20" value="c"> To provide a vacuum break during disengagement.</label>
@@ -234,7 +234,7 @@
       </div>
 
 <div class="question">
-        <p><strong>21. What component is considered the foundation of the synchronizer unit, as it is splined to the output shaft and typically locked in place with snap rings?</strong></p>
+        <p><strong>What component is considered the foundation of the synchronizer unit, as it is splined to the output shaft and typically locked in place with snap rings?</strong></p>
         <label><input type="radio" name="q21" value="a"> The Blocking Ring</label>
         <label><input type="radio" name="q21" value="b"> The Sleeve</label>
         <label><input type="radio" name="q21" value="c"> The Hub</label>
@@ -242,7 +242,7 @@
       </div>
 
 <div class="question">
-        <p><strong>22. The synchronizer sleeve is grooved on its outer circumference to accommodate which component?</strong></p>
+        <p><strong>The synchronizer sleeve is grooved on its outer circumference to accommodate which component?</strong></p>
         <label><input type="radio" name="q22" value="a"> The blocking ring</label>
         <label><input type="radio" name="q22" value="b"> The hub inserts</label>
         <label><input type="radio" name="q22" value="c"> The shift fork</label>
@@ -250,7 +250,7 @@
       </div>
 
 <div class="question">
-        <p><strong>23. What is the specific function of the three inserts (keys or struts) within the synchronizer hub?</strong></p>
+        <p><strong>What is the specific function of the three inserts (keys or struts) within the synchronizer hub?</strong></p>
         <label><input type="radio" name="q23" value="a"> To hold the blocking ring in position permanently.</label>
         <label><input type="radio" name="q23" value="b"> To serve as detents for the sleeve, centre it on the hub, and give it a neutral location.</label>
         <label><input type="radio" name="q23" value="c"> To directly connect the output gear to the sleeve.</label>
@@ -258,7 +258,7 @@
       </div>
 
 <div class="question">
-        <p><strong>24. A key distinction in the power path of a transaxle is that the output shaft runs:</strong></p>
+        <p><strong>A key distinction in the power path of a transaxle is that the output shaft runs:</strong></p>
         <label><input type="radio" name="q24" value="a"> Directly behind the input shaft, locked together in 4th gear.</label>
         <label><input type="radio" name="q24" value="b"> Parallel to the input shaft and is never locked to it.</label>
         <label><input type="radio" name="q24" value="c"> At 0.722 times the speed of the input shaft in overdrive.</label>
@@ -266,7 +266,7 @@
       </div>
 
 <div class="question">
-        <p><strong>25. The shift mechanism is designed to select a gear and also provides a means of holding the transmission in that speed range. What system is responsible for counteracting the tendency for the transmission to hop or jump out of gear?</strong></p>
+        <p><strong>The shift mechanism is designed to select a gear and also provides a means of holding the transmission in that speed range. What system is responsible for counteracting the tendency for the transmission to hop or jump out of gear?</strong></p>
         <label><input type="radio" name="q25" value="a"> The Interlock system</label>
         <label><input type="radio" name="q25" value="b"> The Synchronizer system</label>
         <label><input type="radio" name="q25" value="c"> The Detent system</label>
@@ -274,7 +274,7 @@
       </div>
 
 <div class="question">
-        <p><strong>26. The detent system provides a positive location for the gear selected. What physical sensation does this system provide to the driver?</strong></p>
+        <p><strong>The detent system provides a positive location for the gear selected. What physical sensation does this system provide to the driver?</strong></p>
         <label><input type="radio" name="q26" value="a"> The reduction of gear clash noise.</label>
         <label><input type="radio" name="q26" value="b"> The feeling of the clutch engaging smoothly.</label>
         <label><input type="radio" name="q26" value="c"> The feeling of hitting a stop, indicating the shift is completed.</label>
@@ -282,7 +282,7 @@
       </div>
 
 <div class="question">
-        <p><strong>27. The detent system often consists of which components, usually combined with the interlock system?</strong></p>
+        <p><strong>The detent system often consists of which components, usually combined with the interlock system?</strong></p>
         <label><input type="radio" name="q27" value="a"> Cables and linkages</label>
         <label><input type="radio" name="q27" value="b"> Shift rails and shift forks</label>
         <label><input type="radio" name="q27" value="c"> Notches machined into the shift rails and a system of balls, plungers or pins, and springs.</label>
@@ -290,7 +290,7 @@
       </div>
 
 <div class="question">
-        <p><strong>28. What is the primary purpose of the interlock system in a manual transmission?</strong></p>
+        <p><strong>What is the primary purpose of the interlock system in a manual transmission?</strong></p>
         <label><input type="radio" name="q28" value="a"> To provide a neutral location for the shift rails.</label>
         <label><input type="radio" name="q28" value="b"> To increase the spring tension on the detent plug.</label>
         <label><input type="radio" name="q28" value="c"> To prevent the driver from selecting two gears at once.</label>
@@ -298,7 +298,7 @@
       </div>
 
 <div class="question">
-        <p><strong>29. If the shift rail is held stationary by the interlock system, what is the consequence?</strong></p>
+        <p><strong>If the shift rail is held stationary by the interlock system, what is the consequence?</strong></p>
         <label><input type="radio" name="q29" value="a"> The detent system cannot provide a positive location.</label>
         <label><input type="radio" name="q29" value="b"> The transaxle shifts into freewheeling.</label>
         <label><input type="radio" name="q29" value="c"> No other gear can be selected.</label>
@@ -306,7 +306,7 @@
       </div>
 
 <div class="question">
-        <p><strong>30. Shift mechanisms can generally be broken down into which two broad categories of systems?</strong></p>
+        <p><strong>Shift mechanisms can generally be broken down into which two broad categories of systems?</strong></p>
         <label><input type="radio" name="q30" value="a"> Synchromesh and Constant Mesh</label>
         <label><input type="radio" name="q30" value="b"> Hydraulic and Mechanical</label>
         <label><input type="radio" name="q30" value="c"> Internal and External</label>
@@ -314,7 +314,7 @@
       </div>
 
 <div class="question">
-        <p><strong>31. Which type of external shift mechanism is currently the most widely used system for transaxle linkage?</strong></p>
+        <p><strong>Which type of external shift mechanism is currently the most widely used system for transaxle linkage?</strong></p>
         <label><input type="radio" name="q31" value="a"> Mechanical rods and levers</label>
         <label><input type="radio" name="q31" value="b"> Column shift linkage</label>
         <label><input type="radio" name="q31" value="c"> Floor shift linkage (often using cables or rods)</label>
@@ -322,7 +322,7 @@
       </div>
 
 <div class="question">
-        <p><strong>32. In the operation of a five-speed transmission in Neutral, what is the state of the power flow?</strong></p>
+        <p><strong>In the operation of a five-speed transmission in Neutral, what is the state of the power flow?</strong></p>
         <label><input type="radio" name="q32" value="a"> The output shaft is locked to the input shaft, but the wheels are not driven.</label>
         <label><input type="radio" name="q32" value="b"> The input shaft is disconnected from the engine by the clutch.</label>
         <label><input type="radio" name="q32" value="c"> The input shaft and all gears turn, but the output shaft does not, so no power is transmitted.</label>
@@ -330,7 +330,7 @@
       </div>
 
 <div class="question">
-        <p><strong>33. What is the primary path of power through 1st gear?</strong></p>
+        <p><strong>What is the primary path of power through 1st gear?</strong></p>
         <label><input type="radio" name="q33" value="a"> Input shaft, directly to output shaft via the synchronizer.</label>
         <label><input type="radio" name="q33" value="b"> Input shaft, cluster drive gear, output 1st gear, then to the mainshaft reverse gear.</label>
         <label><input type="radio" name="q33" value="c"> Input shaft and gear, cluster drive gear, cluster 1st gear, output 1st gear, locked by the synchronizer to the output shaft.</label>
@@ -338,7 +338,7 @@
       </div>
 
 <div class="question">
-        <p><strong>34. When the driver selects Reverse gear in a manual transmission, which additional component is required to achieve opposite direction of rotation?</strong></p>
+        <p><strong>When the driver selects Reverse gear in a manual transmission, which additional component is required to achieve opposite direction of rotation?</strong></p>
         <label><input type="radio" name="q34" value="a"> The use of a different synchronizer sleeve (5th/Reverse).</label>
         <label><input type="radio" name="q34" value="b"> The direct connection of the input shaft to the cluster gear.</label>
         <label><input type="radio" name="q34" value="c"> The reverse idler gear, which drives the output shaft in a direction opposite to the input shaft rotation.</label>
@@ -346,7 +346,7 @@
       </div>
 
 <div class="question">
-        <p><strong>35. The source explains that spur gears are often used for the Reverse gear in many transaxles. What is the reason for this design choice?</strong></p>
+        <p><strong>The source explains that spur gears are often used for the Reverse gear in many transaxles. What is the reason for this design choice?</strong></p>
         <label><input type="radio" name="q35" value="a"> Spur gears are quieter than helical gears.</label>
         <label><input type="radio" name="q35" value="b"> Spur gears are less expensive than helical gears.</label>
         <label><input type="radio" name="q35" value="c"> Spur gears generate less end thrust than helical gears.</label>
@@ -354,7 +354,7 @@
       </div>
 
 <div class="question">
-        <p><strong>36. In the transaxle power path for 5th gear (Overdrive), which components free wheel when the axle ring gear is driven by the 5th speed output pinion gear (#8)?</strong></p>
+        <p><strong>In the transaxle power path for 5th gear (Overdrive), which components free wheel when the axle ring gear is driven by the 5th speed output pinion gear (#8)?</strong></p>
         <label><input type="radio" name="q36" value="a"> The input cluster shaft.</label>
         <label><input type="radio" name="q36" value="b"> The output shaft pinion gear (#10) and its shaft.</label>
         <label><input type="radio" name="q36" value="c"> The 5th speed synchronizer sleeve.</label>
@@ -362,7 +362,7 @@
       </div>
 
 <div class="question">
-        <p><strong>37. Manual transmissions and transaxles typically use what method to circulate lubricant to the internal components?</strong></p>
+        <p><strong>Manual transmissions and transaxles typically use what method to circulate lubricant to the internal components?</strong></p>
         <label><input type="radio" name="q37" value="a"> A pressure pump system, similar to an engine.</label>
         <label><input type="radio" name="q37" value="b"> An exhaust port system to spray oil.</label>
         <label><input type="radio" name="q37" value="c"> A splash system, where rotating gears throw oil onto the shafts, bearings, and gears.</label>
@@ -370,7 +370,7 @@
       </div>
 
 <div class="question">
-        <p><strong>38. According to the manufacturer’s specifications, which of the following lubricants may be specified for use in manual transmissions or transaxles?</strong></p>
+        <p><strong>According to the manufacturer’s specifications, which of the following lubricants may be specified for use in manual transmissions or transaxles?</strong></p>
         <label><input type="radio" name="q38" value="a"> Gear oil</label>
         <label><input type="radio" name="q38" value="b"> Engine oil</label>
         <label><input type="radio" name="q38" value="c"> Automatic transmission or transaxle fluid</label>
@@ -378,7 +378,7 @@
       </div>
 
 <div class="question">
-        <p><strong>39. What is the purpose of the vent incorporated into the transmission or transaxle case?</strong></p>
+        <p><strong>What is the purpose of the vent incorporated into the transmission or transaxle case?</strong></p>
         <label><input type="radio" name="q39" value="a"> To allow moisture to escape from the oil.</label>
         <label><input type="radio" name="q39" value="b"> To provide a passage for oil to cool the shift rails.</label>
         <label><input type="radio" name="q39" value="c"> To allow air to escape to prevent pressure buildup, and to allow air in to prevent a vacuum from being created.</label>
@@ -386,7 +386,7 @@
       </div>
 
 <div class="question">
-        <p><strong>40. Low pressure inside a transmission housing, caused by cooling when the vehicle is parked, is detrimental because it can cause what material to be drawn past the seal lips?</strong></p>
+        <p><strong>Low pressure inside a transmission housing, caused by cooling when the vehicle is parked, is detrimental because it can cause what material to be drawn past the seal lips?</strong></p>
         <label><input type="radio" name="q40" value="a"> Gear oil vapors</label>
         <label><input type="radio" name="q40" value="b"> Excessive lubricant</label>
         <label><input type="radio" name="q40" value="c"> Dirt and other foreign material</label>
@@ -394,7 +394,7 @@
       </div>
 
 <div class="question">
-        <p><strong>41. How does the rotating oil help cool the transmission components?</strong></p>
+        <p><strong>How does the rotating oil help cool the transmission components?</strong></p>
         <label><input type="radio" name="q41" value="a"> It transfers heat to the cluster gears, which are submerged.</label>
         <label><input type="radio" name="q41" value="b"> It carries heat to the synchronizer unit, where it dissipates through the sleeve.</label>
         <label><input type="radio" name="q41" value="c"> Heat is picked up by the circulating oil and carried from hot spots to the transmission or transaxle case, where it is cooled by the passing airstream.</label>
@@ -402,7 +402,7 @@
       </div>
 
 <div class="question">
-        <p><strong>42. What component or part is responsible for the movement of the shift forks that are positioned in the grooves on the circumference of the synchronizer sleeves?</strong></p>
+        <p><strong>What component or part is responsible for the movement of the shift forks that are positioned in the grooves on the circumference of the synchronizer sleeves?</strong></p>
         <label><input type="radio" name="q42" value="a"> The detent plunger</label>
         <label><input type="radio" name="q42" value="b"> The selector arm</label>
         <label><input type="radio" name="q42" value="c"> The shift rails</label>
@@ -410,7 +410,7 @@
       </div>
 
 <div class="question">
-        <p><strong>43. Which bearing types are commonly used in manual transmissions and transaxles to support shafts?</strong></p>
+        <p><strong>Which bearing types are commonly used in manual transmissions and transaxles to support shafts?</strong></p>
         <label><input type="radio" name="q43" value="a"> Bushings and ball bearings only.</label>
         <label><input type="radio" name="q43" value="b"> Ball, roller, needle, and bushings.</label>
         <label><input type="radio" name="q43" value="c"> Thrust and pilot bearings only.</label>
@@ -418,7 +418,7 @@
       </div>
 
 <div class="question">
-        <p><strong>44. Thrust washers may be supplied in packages of selective thicknesses. Why are they often colour coded or ink stamped?</strong></p>
+        <p><strong>Thrust washers may be supplied in packages of selective thicknesses. Why are they often colour coded or ink stamped?</strong></p>
         <label><input type="radio" name="q44" value="a"> To identify the type of metal (ferrous or non-ferrous).</label>
         <label><input type="radio" name="q44" value="b"> To indicate the side that contacts the rotating shaft.</label>
         <label><input type="radio" name="q44" value="c"> To identify their specific thickness.</label>
@@ -426,7 +426,7 @@
       </div>
 
 <div class="question">
-        <p><strong>45. In the power flow diagram for reverse gear (Figure 25), when the reverse idler gear turns, what is the consequence for the output shaft&#x27;s rotation?</strong></p>
+        <p><strong>In the power flow diagram for reverse gear (Figure 25), when the reverse idler gear turns, what is the consequence for the output shaft&#x27;s rotation?</strong></p>
         <label><input type="radio" name="q45" value="a"> It freewheels, allowing the output shaft to rotate in the same direction as the input.</label>
         <label><input type="radio" name="q45" value="b"> It drives the output shaft in a direction opposite to the input shaft rotation.</label>
         <label><input type="radio" name="q45" value="c"> It locks the 5th/Reverse synchronizer sleeve to the neutral position.</label>
@@ -434,7 +434,7 @@
       </div>
 
 <div class="question">
-        <p><strong>46. When a main shaft is replaced, what related components are suggested as common replacement parts/related sales opportunities?</strong></p>
+        <p><strong>When a main shaft is replaced, what related components are suggested as common replacement parts/related sales opportunities?</strong></p>
         <label><input type="radio" name="q46" value="a"> Only seals and gaskets.</label>
         <label><input type="radio" name="q46" value="b"> Only the shift fork and detents.</label>
         <label><input type="radio" name="q46" value="c"> Gears, thrust washers, bearings, and lubricant.</label>
@@ -442,7 +442,7 @@
       </div>
 
 <div class="question">
-        <p><strong>47. When a synchronizer component has failed, which related replacement components should be identified as potential sales opportunities?</strong></p>
+        <p><strong>When a synchronizer component has failed, which related replacement components should be identified as potential sales opportunities?</strong></p>
         <label><input type="radio" name="q47" value="a"> Clutch fork and housing.</label>
         <label><input type="radio" name="q47" value="b"> Thrust washers, bearings, seals, snap rings, gears, and lubricant.</label>
         <label><input type="radio" name="q47" value="c"> Only the hub and sleeve.</label>
@@ -450,7 +450,7 @@
       </div>
 
 <div class="question">
-        <p><strong>48. The two places a magnet may be found in a manual transmission case to catch metal filings are:</strong></p>
+        <p><strong>The two places a magnet may be found in a manual transmission case to catch metal filings are:</strong></p>
         <label><input type="radio" name="q48" value="a"> On the output shaft and the input shaft.</label>
         <label><input type="radio" name="q48" value="b"> On the front and rear bearing retainers.</label>
         <label><input type="radio" name="q48" value="c"> Mounted at the bottom of the transmission case, or as part of the filler and/or drain plug.</label>
@@ -458,7 +458,7 @@
       </div>
 
 <div class="question">
-        <p><strong>49. What is the definition of end play in the context of shafts and components within the transmission?</strong></p>
+        <p><strong>What is the definition of end play in the context of shafts and components within the transmission?</strong></p>
         <label><input type="radio" name="q49" value="a"> Pressure applied to the end of a shaft (End Thrust).</label>
         <label><input type="radio" name="q49" value="b"> The force that prevents hopping out of gear (Detent).</label>
         <label><input type="radio" name="q49" value="c"> The measured amount of lengthwise (axial) movement between two parts.</label>
@@ -466,7 +466,7 @@
       </div>
 
 <div class="question">
-        <p><strong>50. Based on the objectives, what are the two gear types most common to light-duty manual transmissions or transaxles?</strong></p>
+        <p><strong>Based on the objectives, what are the two gear types most common to light-duty manual transmissions or transaxles?</strong></p>
         <label><input type="radio" name="q50" value="a"> Planetary and Hypoid</label>
         <label><input type="radio" name="q50" value="b"> Bevel and Spur</label>
         <label><input type="radio" name="q50" value="c"> Spur and Helical</label>

--- a/270202-test/270202e - Heavy-Duty Manual Transmissions and PTOs.html
+++ b/270202-test/270202e - Heavy-Duty Manual Transmissions and PTOs.html
@@ -71,7 +71,7 @@
 
 
         <div class="question">
-        <p><strong>1. What is the fundamental difference in design between a synchronized constant mesh transmission and the older sliding gear transmission?</strong></p>
+        <p><strong>What is the fundamental difference in design between a synchronized constant mesh transmission and the older sliding gear transmission?</strong></p>
         <label><input type="radio" name="q1" value="a"> Sliding gear transmissions use countershafts, while constant mesh transmissions use a mainshaft.</label>
         <label><input type="radio" name="q1" value="b"> In constant mesh transmissions, the gears are always in mesh with the cluster gears.</label>
         <label><input type="radio" name="q1" value="c"> Sliding gear transmissions use dog teeth, while constant mesh transmissions use shift collars.</label>
@@ -81,7 +81,7 @@
 
 
       <div class="question">
-        <p><strong>2. What is the approximate maximum input torque rating, expressed in pound-feet (lb/ft), for the example transmission labeled "RITL O F - 16 7 18 A" by Eaton Fuller?</strong></p>
+        <p><strong>What is the approximate maximum input torque rating, expressed in pound-feet (lb/ft), for the example transmission labeled "RITL O F - 16 7 18 A" by Eaton Fuller?</strong></p>
         <label><input type="radio" name="q2" value="a"> 700 lb/ft</label>
         <label><input type="radio" name="q2" value="b"> 1000 lb/ft</label>
         <label><input type="radio" name="q2" value="c"> 1600 lb/ft</label>
@@ -91,7 +91,7 @@
 
 
       <div class="question">
-        <p><strong>3. The nomenclature suffix (x) 100 on an Eaton Fuller transmission model number signifies what measurement?</strong></p>
+        <p><strong>The nomenclature suffix (x) 100 on an Eaton Fuller transmission model number signifies what measurement?</strong></p>
         <label><input type="radio" name="q3" value="a"> The number of forward gear ratios available.</label>
         <label><input type="radio" name="q3" value="b"> The maximum engine horsepower rating.</label>
         <label><input type="radio" name="q3" value="c"> The nominal torque capacity in lb/ft.</label>
@@ -101,7 +101,7 @@
 
 
       <div class="question">
-        <p><strong>4. A heavy-duty transmission described as an 18-speed, multiple countershaft transmission that uses an autoshift system would be classified as what kind of transmission?</strong></p>
+        <p><strong>A heavy-duty transmission described as an 18-speed, multiple countershaft transmission that uses an autoshift system would be classified as what kind of transmission?</strong></p>
         <label><input type="radio" name="q4" value="a"> Manual, five-speed, overdrive, synchronized.</label>
         <label><input type="radio" name="q4" value="b"> Autoshift, multiple countershaft.</label>
         <label><input type="radio" name="q4" value="c"> Collar shift, single countershaft, direct drive.</label>
@@ -111,7 +111,7 @@
 
 
       <div class="question">
-        <p><strong>5. What is the primary function of the transmission in conjunction with the clutch, enabling the vehicle to move from a standstill to highway speed?</strong></p>
+        <p><strong>What is the primary function of the transmission in conjunction with the clutch, enabling the vehicle to move from a standstill to highway speed?</strong></p>
         <label><input type="radio" name="q5" value="a"> To increase the available engine horsepower as road conditions change.</label>
         <label><input type="radio" name="q5" value="b"> To maintain a constant gear ratio that provides maximum torque.</label>
         <label><input type="radio" name="q5" value="c"> To adjust the available engine torque to the changing road and load conditions.</label>
@@ -121,7 +121,7 @@
 
 
       <div class="question">
-        <p><strong>6. In a heavy transport truck equipped with a five-speed main transmission and a four-speed remote auxiliary transmission, how many total possible forward gear selections are available?</strong></p>
+        <p><strong>In a heavy transport truck equipped with a five-speed main transmission and a four-speed remote auxiliary transmission, how many total possible forward gear selections are available?</strong></p>
         <label><input type="radio" name="q6" value="a"> 9</label>
         <label><input type="radio" name="q6" value="b"> 15</label>
         <label><input type="radio" name="q6" value="c"> 20</label>
@@ -131,7 +131,7 @@
 
 
       <div class="question">
-        <p><strong>7. A heavy-duty transmission utilizes a five-speed main section and a four-speed auxiliary section. If the first gear in the auxiliary section is used only in low range, how many usable gear ratios does the overall transmission provide?</strong></p>
+        <p><strong>A heavy-duty transmission utilizes a five-speed main section and a four-speed auxiliary section. If the first gear in the auxiliary section is used only in low range, how many usable gear ratios does the overall transmission provide?</strong></p>
         <label><input type="radio" name="q7" value="a"> 20</label>
         <label><input type="radio" name="q7" value="b"> 18</label>
         <label><input type="radio" name="q7" value="c"> 15</label>
@@ -141,7 +141,7 @@
 
 
       <div class="question">
-        <p><strong>8. A heavy-duty transmission main section features an overdrive arrangement, such as 0.74:1. This ratio indicates that for every 1.0 rotation of the mainshaft input, the output shaft will rotate:</strong></p>
+        <p><strong>A heavy-duty transmission main section features an overdrive arrangement, such as 0.74:1. This ratio indicates that for every 1.0 rotation of the mainshaft input, the output shaft will rotate:</strong></p>
         <label><input type="radio" name="q8" value="a"> 1.0 revolution (Direct Drive).</label>
         <label><input type="radio" name="q8" value="b"> More than 1.0 revolution (Speed Increase).</label>
         <label><input type="radio" name="q8" value="c"> 0.74 revolutions (Speed Reduction).</label>
@@ -151,7 +151,7 @@
 
 
       <div class="question">
-        <p><strong>9. A multiple countershaft transmission offers the same torque capacity as a single countershaft design but is more compact and requires fewer components. This is achieved because the outward force on each countershaft is reduced to what fraction of the force applied to a single countershaft?</strong></p>
+        <p><strong>A multiple countershaft transmission offers the same torque capacity as a single countershaft design but is more compact and requires fewer components. This is achieved because the outward force on each countershaft is reduced to what fraction of the force applied to a single countershaft?</strong></p>
         <label><input type="radio" name="q9" value="a"> One-quarter</label>
         <label><input type="radio" name="q9" value="b"> One-third</label>
         <label><input type="radio" name="q9" value="c"> One-half</label>
@@ -161,7 +161,7 @@
 
 
       <div class="question">
-        <p><strong>10. Due to the torque split in a twin countershaft design, the supporting bearings and countershafts can be considerably smaller and lighter because they are required to withstand:</strong></p>
+        <p><strong>Due to the torque split in a twin countershaft design, the supporting bearings and countershafts can be considerably smaller and lighter because they are required to withstand:</strong></p>
         <label><input type="radio" name="q10" value="a"> Doubled tooth contact area.</label>
         <label><input type="radio" name="q10" value="b"> Reduced torsional vibration.</label>
         <label><input type="radio" name="q10" value="c"> Smaller forces.</label>
@@ -171,7 +171,7 @@
 
 
       <div class="question">
-        <p><strong>11. What is the most important functional advantage of a twin or triple countershaft transmission design over a single countershaft design?</strong></p>
+        <p><strong>What is the most important functional advantage of a twin or triple countershaft transmission design over a single countershaft design?</strong></p>
         <label><input type="radio" name="q11" value="a"> The path of power is lengthened for efficiency [30a].</label>
         <label><input type="radio" name="q11" value="b"> Additional gear tooth contact adds strength.</label>
         <label><input type="radio" name="q11" value="c"> The elimination of synchronizers simplifies the assembly [30d].</label>
@@ -181,7 +181,7 @@
 
 
       <div class="question">
-        <p><strong>12. The heavy-duty transmission assembly receives torque from the engine via the clutch discs, which are splined to which component?</strong></p>
+        <p><strong>The heavy-duty transmission assembly receives torque from the engine via the clutch discs, which are splined to which component?</strong></p>
         <label><input type="radio" name="q12" value="a"> The main drive gear</label>
         <label><input type="radio" name="q12" value="b"> The mainshaft</label>
         <label><input type="radio" name="q12" value="c"> The transmission input shaft</label>
@@ -191,7 +191,7 @@
 
 
       <div class="question">
-        <p><strong>13. In a non-synchronized heavy-duty transmission, the input shaft is required to stop rotating when the operator shifts into a starting or reverse gear. What component is responsible for stopping the input shaft?</strong></p>
+        <p><strong>In a non-synchronized heavy-duty transmission, the input shaft is required to stop rotating when the operator shifts into a starting or reverse gear. What component is responsible for stopping the input shaft?</strong></p>
         <label><input type="radio" name="q13" value="a"> The detent ball and spring</label>
         <label><input type="radio" name="q13" value="b"> The interlock pin</label>
         <label><input type="radio" name="q13" value="c"> The clutch brake</label>
@@ -201,7 +201,7 @@
 
 
       <div class="question">
-        <p><strong>14. When the clutch brake is applied, how does it stop the input shaft from turning?</strong></p>
+        <p><strong>When the clutch brake is applied, how does it stop the input shaft from turning?</strong></p>
         <label><input type="radio" name="q14" value="a"> The range cylinder pushes air onto the main drive gear.</label>
         <label><input type="radio" name="q14" value="b"> It is squeezed between the release bearing and the input shaft bearing cover.</label>
         <label><input type="radio" name="q14" value="c"> The mainshaft gear floating design arrests rotation.</label>
@@ -211,7 +211,7 @@
 
 
       <div class="question">
-        <p><strong>15. What specific feature is included in the input shaft design to eliminate the need for a lip seal in a high-heat and dirty environment?</strong></p>
+        <p><strong>What specific feature is included in the input shaft design to eliminate the need for a lip seal in a high-heat and dirty environment?</strong></p>
         <label><input type="radio" name="q15" value="a"> Roller bearings</label>
         <label><input type="radio" name="q15" value="b"> A windback seal system</label>
         <label><input type="radio" name="q15" value="c"> An O-ring seal system</label>
@@ -221,7 +221,7 @@
 
 
       <div class="question">
-        <p><strong>16. In a multiple countershaft transmission, the mainshaft gear is held suspended or "floating" between the countershafts. What component is eliminated due to this floating design?</strong></p>
+        <p><strong>In a multiple countershaft transmission, the mainshaft gear is held suspended or "floating" between the countershafts. What component is eliminated due to this floating design?</strong></p>
         <label><input type="radio" name="q16" value="a"> Thrust washers.</label>
         <label><input type="radio" name="q16" value="b"> Bearings (or bushings/shaft sleeves) between the mainshaft and mainshaft gears.</label>
         <label><input type="radio" name="q16" value="c"> Clutch teeth on the mainshaft gear.</label>
@@ -231,7 +231,7 @@
 
 
       <div class="question">
-        <p><strong>17. The use of a twin countershaft design allows for the utilization of less expensive straight spur gears in the main section. What required component does this spur gear design help eliminate?</strong></p>
+        <p><strong>The use of a twin countershaft design allows for the utilization of less expensive straight spur gears in the main section. What required component does this spur gear design help eliminate?</strong></p>
         <label><input type="radio" name="q17" value="a"> The need for a clutch brake.</label>
         <label><input type="radio" name="q17" value="b"> Thrust control washers.</label>
         <label><input type="radio" name="q17" value="c"> The synchronizer central hub.</label>
@@ -241,7 +241,7 @@
 
 
       <div class="question">
-        <p><strong>18. What characteristic of the gear width is allowed in a twin countershaft transmission compared to a single countershaft transmission designed to handle the same torque?</strong></p>
+        <p><strong>What characteristic of the gear width is allowed in a twin countershaft transmission compared to a single countershaft transmission designed to handle the same torque?</strong></p>
         <label><input type="radio" name="q18" value="a"> The gear width must be doubled.</label>
         <label><input type="radio" name="q18" value="b"> The gear width must be the same size.</label>
         <label><input type="radio" name="q18" value="c"> The gear width can theoretically be half as wide.</label>
@@ -251,7 +251,7 @@
 
 
       <div class="question">
-        <p><strong>19. Torque is transferred from the engine to the selected mainshaft gear via the countershafts. What is the final step in the main section power path before torque is sent to the auxiliary section?</strong></p>
+        <p><strong>Torque is transferred from the engine to the selected mainshaft gear via the countershafts. What is the final step in the main section power path before torque is sent to the auxiliary section?</strong></p>
         <label><input type="radio" name="q19" value="a"> The mainshaft gear floats away from the countershafts.</label>
         <label><input type="radio" name="q19" value="b"> The output shaft is supported by a large snap ring.</label>
         <label><input type="radio" name="q19" value="c"> It is transferred through the sliding clutch to the mainshaft.</label>
@@ -261,7 +261,7 @@
 
 
       <div class="question">
-        <p><strong>20. What is the primary method used to maintain the proper alignment of the several housings bolted together to form a multiple countershaft transmission assembly?</strong></p>
+        <p><strong>What is the primary method used to maintain the proper alignment of the several housings bolted together to form a multiple countershaft transmission assembly?</strong></p>
         <label><input type="radio" name="q20" value="a"> Shouldered bolts.</label>
         <label><input type="radio" name="q20" value="b"> Tapered plugs.</label>
         <label><input type="radio" name="q20" value="c"> Precise dowelling.</label>
@@ -271,7 +271,7 @@
 
 
       <div class="question">
-        <p><strong>21. What component is used inside the heavy-duty transmission to take up end thrust loads and prevent gears from rubbing on the transmission housing?</strong></p>
+        <p><strong>What component is used inside the heavy-duty transmission to take up end thrust loads and prevent gears from rubbing on the transmission housing?</strong></p>
         <label><input type="radio" name="q21" value="a"> Interlock pins</label>
         <label><input type="radio" name="q21" value="b"> Snap rings</label>
         <label><input type="radio" name="q21" value="c"> Thrust washers</label>
@@ -281,7 +281,7 @@
 
 
       <div class="question">
-        <p><strong>22. Thrust washers used in heavy-duty transmissions are available in various thicknesses. What feature assists parts technicians and mechanics in identifying their specific thickness?</strong></p>
+        <p><strong>Thrust washers used in heavy-duty transmissions are available in various thicknesses. What feature assists parts technicians and mechanics in identifying their specific thickness?</strong></p>
         <label><input type="radio" name="q22" value="a"> Material composition (aluminum or cast iron).</label>
         <label><input type="radio" name="q22" value="b"> Engraved serial numbers.</label>
         <label><input type="radio" name="q22" value="c"> Colour-coating.</label>
@@ -291,7 +291,7 @@
 
 
       <div class="question">
-        <p><strong>23. In a heavy-duty twin countershaft transmission, how is the rotation of the mainshaft gear accomplished?</strong></p>
+        <p><strong>In a heavy-duty twin countershaft transmission, how is the rotation of the mainshaft gear accomplished?</strong></p>
         <label><input type="radio" name="q23" value="a"> The mainshaft gear is splined directly to the mainshaft.</label>
         <label><input type="radio" name="q23" value="b"> The twin countershaft gears rotate the mainshaft gear.</label>
         <label><input type="radio" name="q23" value="c"> The sliding clutch engages the internal splines of the output shaft.</label>
@@ -301,7 +301,7 @@
 
 
       <div class="question">
-        <p><strong>24. A five-speed main transmission section combined with a three-speed auxiliary transmission provides the operator with how many possible forward gear selections?</strong></p>
+        <p><strong>A five-speed main transmission section combined with a three-speed auxiliary transmission provides the operator with how many possible forward gear selections?</strong></p>
         <label><input type="radio" name="q24" value="a"> 9</label>
         <label><input type="radio" name="q24" value="b"> 15</label>
         <label><input type="radio" name="q24" value="c"> 18</label>
@@ -311,7 +311,7 @@
 
 
       <div class="question">
-        <p><strong>25. The auxiliary section of the transmission is designed to provide which three types of gearing combinations?</strong></p>
+        <p><strong>The auxiliary section of the transmission is designed to provide which three types of gearing combinations?</strong></p>
         <label><input type="radio" name="q25" value="a"> Direct Drive, Reduction, and Overdrive.</label>
         <label><input type="radio" name="q25" value="b"> Range, splitter, and deep reduction.</label>
         <label><input type="radio" name="q25" value="c"> Twin, Triple, and Single reduction.</label>
@@ -321,7 +321,7 @@
 
 
       <div class="question">
-        <p><strong>26. Which type of gearing in the auxiliary section typically accounts for a large ratio change?</strong></p>
+        <p><strong>Which type of gearing in the auxiliary section typically accounts for a large ratio change?</strong></p>
         <label><input type="radio" name="q26" value="a"> Splitter gearing.</label>
         <label><input type="radio" name="q26" value="b"> Deep reduction gearing.</label>
         <label><input type="radio" name="q26" value="c"> Range gearing</label>
@@ -331,7 +331,7 @@
 
 
       <div class="question">
-        <p><strong>27. The auxiliary section of a heavy-duty transmission is generally shifted using what actuation method?</strong></p>
+        <p><strong>The auxiliary section of a heavy-duty transmission is generally shifted using what actuation method?</strong></p>
         <label><input type="radio" name="q27" value="a"> Mechanical linkage.</label>
         <label><input type="radio" name="q27" value="b"> Direct shift levers.</label>
         <label><input type="radio" name="q27" value="c"> Air (pneumatic) signal.</label>
@@ -341,7 +341,7 @@
 
 
       <div class="question">
-        <p><strong>28. The shift linkage required for a heavy-duty compound transmission is typically composed of a mechanical gearshift lever controlling the main section and what other primary component for the auxiliary section control?</strong></p>
+        <p><strong>The shift linkage required for a heavy-duty compound transmission is typically composed of a mechanical gearshift lever controlling the main section and what other primary component for the auxiliary section control?</strong></p>
         <label><input type="radio" name="q28" value="a"> A hydraulic system.</label>
         <label><input type="radio" name="q28" value="b"> An air shift system.</label>
         <label><input type="radio" name="q28" value="c"> A complex cable linkage.</label>
@@ -351,7 +351,7 @@
 
 
       <div class="question">
-        <p><strong>29. If the deep reduction option is selected in a three-speed auxiliary section, the operator gains access to gear selections exclusively within which main section position?</strong></p>
+        <p><strong>If the deep reduction option is selected in a three-speed auxiliary section, the operator gains access to gear selections exclusively within which main section position?</strong></p>
         <label><input type="radio" name="q29" value="a"> High range only.</label>
         <label><input type="radio" name="q29" value="b"> Overdrive only.</label>
         <label><input type="radio" name="q29" value="c"> Low range only.</label>
@@ -361,7 +361,7 @@
 
 
       <div class="question">
-        <p><strong>30. In a four-speed auxiliary section, the operator has the ability to "split" every main section gear while operating in low and high range. What does a "split" (or splitter gearing) provide?</strong></p>
+        <p><strong>In a four-speed auxiliary section, the operator has the ability to "split" every main section gear while operating in low and high range. What does a "split" (or splitter gearing) provide?</strong></p>
         <label><input type="radio" name="q30" value="a"> A large ratio change.</label>
         <label><input type="radio" name="q30" value="b"> A small ratio change.</label>
         <label><input type="radio" name="q30" value="c"> Deep reduction.</label>
@@ -371,7 +371,7 @@
 
 
       <div class="question">
-        <p><strong>31. When the sliding clutch in a two-speed auxiliary section is moved forward, what operational combination is achieved?</strong></p>
+        <p><strong>When the sliding clutch in a two-speed auxiliary section is moved forward, what operational combination is achieved?</strong></p>
         <label><input type="radio" name="q31" value="a"> Low range, providing a large reduction.</label>
         <label><input type="radio" name="q31" value="b"> Deep reduction (underdrive).</label>
         <label><input type="radio" name="q31" value="c"> High range, giving a direct drive (1:1).</label>
@@ -381,7 +381,7 @@
 
 
       <div class="question">
-        <p><strong>32. The main section of a typical twin or triple countershaft heavy-duty transmission is constructed as a:</strong></p>
+        <p><strong>The main section of a typical twin or triple countershaft heavy-duty transmission is constructed as a:</strong></p>
         <label><input type="radio" name="q32" value="a"> Synchronized, sliding gear design.</label>
         <label><input type="radio" name="q32" value="b"> Full synchromesh, constant mesh design.</label>
         <label><input type="radio" name="q32" value="c"> Non-synchronized, constant mesh, sliding clutch design.</label>
@@ -391,7 +391,7 @@
 
 
       <div class="question">
-        <p><strong>33. What is the primary disadvantage of earlier remote auxiliary transmission arrangements compared to modern compound transmissions?</strong></p>
+        <p><strong>What is the primary disadvantage of earlier remote auxiliary transmission arrangements compared to modern compound transmissions?</strong></p>
         <label><input type="radio" name="q33" value="a"> Remote systems were shifted using non-synchronized designs.</label>
         <label><input type="radio" name="q33" value="b"> The shift linkage systems were highly susceptible to wear and damage from falling objects.</label>
         <label><input type="radio" name="q33" value="c"> They could only provide a maximum of 12 usable gears.</label>
@@ -401,7 +401,7 @@
 
 
       <div class="question">
-        <p><strong>34. The main purpose of the transmission output shaft is to:</strong></p>
+        <p><strong>The main purpose of the transmission output shaft is to:</strong></p>
         <label><input type="radio" name="q34" value="a"> Receive torque from the engine via the clutch.</label>
         <label><input type="radio" name="q34" value="b"> Support the mainshaft gear in a floating design.</label>
         <label><input type="radio" name="q34" value="c"> Deliver torque to the driveline.</label>
@@ -411,7 +411,7 @@
 
 
       <div class="question">
-        <p><strong>35. The output shaft in the auxiliary section is typically supported by which type of bearing?</strong></p>
+        <p><strong>The output shaft in the auxiliary section is typically supported by which type of bearing?</strong></p>
         <label><input type="radio" name="q35" value="a"> Needle roller bearings.</label>
         <label><input type="radio" name="q35" value="b"> Tapered roller bearings.</label>
         <label><input type="radio" name="q35" value="c"> Ball bearings.</label>
@@ -421,7 +421,7 @@
 
 
       <div class="question">
-        <p><strong>36. Which type of synchronizer is most popular in heavy-duty truck applications due to its use in larger transmissions, though it is a multi-piece assembly?</strong></p>
+        <p><strong>Which type of synchronizer is most popular in heavy-duty truck applications due to its use in larger transmissions, though it is a multi-piece assembly?</strong></p>
         <label><input type="radio" name="q36" value="a"> Block or Cone type.</label>
         <label><input type="radio" name="q36" value="b"> Pin type</label>
         <label><input type="radio" name="q36" value="c"> Plate and disc type.</label>
@@ -431,7 +431,7 @@
 
 
       <div class="question">
-        <p><strong>37. The synchronizer used for the range shift in the auxiliary section is designed to match the speed of the gear being engaged with the speed of which other component?</strong></p>
+        <p><strong>The synchronizer used for the range shift in the auxiliary section is designed to match the speed of the gear being engaged with the speed of which other component?</strong></p>
         <label><input type="radio" name="q37" value="a"> The main drive gear.</label>
         <label><input type="radio" name="q37" value="b"> The auxiliary countershaft.</label>
         <label><input type="radio" name="q37" value="c"> The output shaft.</label>
@@ -441,7 +441,7 @@
 
 
       <div class="question">
-        <p><strong>38. Due to the increasing torque available from modern engines, what type of gearing is now being used in some auxiliary sections, which requires tapered roller bearings to manage the resulting thrust loads?</strong></p>
+        <p><strong>Due to the increasing torque available from modern engines, what type of gearing is now being used in some auxiliary sections, which requires tapered roller bearings to manage the resulting thrust loads?</strong></p>
         <label><input type="radio" name="q38" value="a"> Spur gearing.</label>
         <label><input type="radio" name="q38" value="b"> Hypoid gearing.</label>
         <label><input type="radio" name="q38" value="c"> Helical gearing</label>
@@ -451,7 +451,7 @@
 
 
       <div class="question">
-        <p><strong>39. The air shift system used for the auxiliary section directs air to either side of a piston to move the desired sliding clutch. What component prevents air from passing from one side of the piston to the other, or into the transmission?</strong></p>
+        <p><strong>The air shift system used for the auxiliary section directs air to either side of a piston to move the desired sliding clutch. What component prevents air from passing from one side of the piston to the other, or into the transmission?</strong></p>
         <label><input type="radio" name="q39" value="a"> Gaskets.</label>
         <label><input type="radio" name="q39" value="b"> O-rings</label>
         <label><input type="radio" name="q39" value="c"> Gaskets and spacers.</label>
@@ -461,7 +461,7 @@
 
 
       <div class="question">
-        <p><strong>40. What is the explicit purpose of the interlock system in a heavy-duty transmission?</strong></p>
+        <p><strong>What is the explicit purpose of the interlock system in a heavy-duty transmission?</strong></p>
         <label><input type="radio" name="q40" value="a"> To hold the shift rail in the selected position (detent function).</label>
         <label><input type="radio" name="q40" value="b"> To provide resistance when selecting 1st or reverse gear.</label>
         <label><input type="radio" name="q40" value="c"> To prevent the operator from selecting more than one gear at a time.</label>
@@ -471,7 +471,7 @@
 
 
       <div class="question">
-        <p><strong>41. The interlock system consists of two metal balls and a pin. When a gear is selected and one shift rail moves, what immediate action does this moving rail initiate in the interlock system?</strong></p>
+        <p><strong>The interlock system consists of two metal balls and a pin. When a gear is selected and one shift rail moves, what immediate action does this moving rail initiate in the interlock system?</strong></p>
         <label><input type="radio" name="q41" value="a"> It forces the ball between the selected rail and the rail beside it to move over and lock the middle rail.</label>
         <label><input type="radio" name="q41" value="b"> It compresses the detent spring, releasing the detent ball.</label>
         <label><input type="radio" name="q41" value="c"> It allows the center rail to move freely.</label>
@@ -481,7 +481,7 @@
 
 
       <div class="question">
-        <p><strong>42. What is the primary function of the spring-loaded plunger used on the first/reverse shift block (lockout device)?</strong></p>
+        <p><strong>What is the primary function of the spring-loaded plunger used on the first/reverse shift block (lockout device)?</strong></p>
         <label><input type="radio" name="q42" value="a"> To apply the clutch brake.</label>
         <label><input type="radio" name="q42" value="b"> To lock the shift rail into neutral.</label>
         <label><input type="radio" name="q42" value="c"> To ensure the operator exerts a definite amount of pressure (conscious effort) before selecting 1st or reverse.</label>
@@ -491,7 +491,7 @@
 
 
       <div class="question">
-        <p><strong>43. Which shift mechanism component takes the operator's input and moves the sliding clutches to engage the desired mainshaft gear?</strong></p>
+        <p><strong>Which shift mechanism component takes the operator's input and moves the sliding clutches to engage the desired mainshaft gear?</strong></p>
         <label><input type="radio" name="q43" value="a"> The air valve shaft.</label>
         <label><input type="radio" name="q43" value="b"> The shifter cover.</label>
         <label><input type="radio" name="q43" value="c"> The shift rails and forks.</label>
@@ -501,7 +501,7 @@
 
 
       <div class="question">
-        <p><strong>44. Heavy-duty transmissions typically utilize a shift lever that is a two-piece design. What component, often found at the bottom of the upper lever, reduces the transmission noise transmitted up into the cab?</strong></p>
+        <p><strong>Heavy-duty transmissions typically utilize a shift lever that is a two-piece design. What component, often found at the bottom of the upper lever, reduces the transmission noise transmitted up into the cab?</strong></p>
         <label><input type="radio" name="q44" value="a"> The spade pin.</label>
         <label><input type="radio" name="q44" value="b"> The tension spring.</label>
         <label><input type="radio" name="q44" value="c"> An isolator</label>
@@ -511,7 +511,7 @@
 
 
       <div class="question">
-        <p><strong>45. In a compound transmission, if the auxiliary section is a four-speed, it incorporates a range set of gearing and what other set of gearing?</strong></p>
+        <p><strong>In a compound transmission, if the auxiliary section is a four-speed, it incorporates a range set of gearing and what other set of gearing?</strong></p>
         <label><input type="radio" name="q45" value="a"> Deep reduction gearing.</label>
         <label><input type="radio" name="q45" value="b"> Splitter gearing.</label>
         <label><input type="radio" name="q45" value="c"> Underdrive gearing.</label>
@@ -521,7 +521,7 @@
 
 
       <div class="question">
-        <p><strong>46. What type of heavy-duty transmission is defined as having both the main and auxiliary transmissions contained within a common transmission case?</strong></p>
+        <p><strong>What type of heavy-duty transmission is defined as having both the main and auxiliary transmissions contained within a common transmission case?</strong></p>
         <label><input type="radio" name="q46" value="a"> Auxiliary transmission.</label>
         <label><input type="radio" name="q46" value="b"> Split-torque transmission.</label>
         <label><input type="radio" name="q46" value="c"> Compound transmission</label>
@@ -531,7 +531,7 @@
 
 
       <div class="question">
-        <p><strong>47. The term dog teeth or dog clutch teeth is often used by manufacturers to describe which component in a constant mesh transmission?</strong></p>
+        <p><strong>The term dog teeth or dog clutch teeth is often used by manufacturers to describe which component in a constant mesh transmission?</strong></p>
         <label><input type="radio" name="q47" value="a"> The internal splines on the shift collar.</label>
         <label><input type="radio" name="q47" value="b"> The gear teeth on the cluster gear.</label>
         <label><input type="radio" name="q47" value="c"> The fine clutch teeth on the output gear.</label>
@@ -541,7 +541,7 @@
 
 
       <div class="question">
-        <p><strong>48. A multiple countershaft transmission that uses three countershafts is structured such that the engine torque is divided equally between them, and they are positioned how far apart?</strong></p>
+        <p><strong>A multiple countershaft transmission that uses three countershafts is structured such that the engine torque is divided equally between them, and they are positioned how far apart?</strong></p>
         <label><input type="radio" name="q48" value="a"> 180°.</label>
         <label><input type="radio" name="q48" value="b"> 120° apart.</label>
         <label><input type="radio" name="q48" value="c"> 90° apart.</label>
@@ -551,7 +551,7 @@
 
 
       <div class="question">
-        <p><strong>49. What is the purpose of the Mainshaft Gear Washer shown in Figure 19, which is positioned on the mainshaft splines and locked in place by a key?</strong></p>
+        <p><strong>What is the purpose of the Mainshaft Gear Washer shown in Figure 19, which is positioned on the mainshaft splines and locked in place by a key?</strong></p>
         <label><input type="radio" name="q49" value="a"> To provide a friction surface for the sliding clutch.</label>
         <label><input type="radio" name="q49" value="b"> To correctly position the mainshaft gear along the mainshaft.</label>
         <label><input type="radio" name="q49" value="c"> To take up end thrust loads (Thrust washer).</label>
@@ -561,7 +561,7 @@
 
 
       <div class="question">
-        <p><strong>50. The output-bearing retainer in a mechanical speedometer system (Figure 32) has a small bore that provides the mounting position for which gear?</strong></p>
+        <p><strong>The output-bearing retainer in a mechanical speedometer system (Figure 32) has a small bore that provides the mounting position for which gear?</strong></p>
         <label><input type="radio" name="q50" value="a"> The speed sensor.</label>
         <label><input type="radio" name="q50" value="b"> The tone ring.</label>
         <label><input type="radio" name="q50" value="c"> The speedometer-driven gear.</label>

--- a/270202-test/270202e-Part2 - Heavy-Duty Manual Transmissions and PTOs.html
+++ b/270202-test/270202e-Part2 - Heavy-Duty Manual Transmissions and PTOs.html
@@ -57,350 +57,350 @@
     <form id="quiz-form" class="exam-form">
 
     <div class="question">
-        <p><strong>1. What is the primary factor that dictates the service life of bearings, shafts, gears, and thrust washers in a heavy-duty transmission?</strong></p>
+        <p><strong>What is the primary factor that dictates the service life of bearings, shafts, gears, and thrust washers in a heavy-duty transmission?</strong></p>
         <label><input type="radio" name="q1" value="a"> The frequency of the torque spikes during gear changes.</label>
         <label><input type="radio" name="q1" value="b"> The maximum load capacity of the transmission housing.</label>
         <label><input type="radio" name="q1" value="c"> The quality of the lubricant used and regularly scheduled lubrication change intervals.</label>
         <label><input type="radio" name="q1" value="d"> The total number of gears utilized in the compound ratio.</label>
       </div>
       <div class="question">
-        <p><strong>2. When referencing the manufacturer’s recommended lubricant chart, what three criteria must be considered when selecting the appropriate lubricant for a heavy-duty transmission?</strong></p>
+        <p><strong>When referencing the manufacturer’s recommended lubricant chart, what three criteria must be considered when selecting the appropriate lubricant for a heavy-duty transmission?</strong></p>
         <label><input type="radio" name="q2" value="a"> Lubricant density, pour point, and heat capacity.</label>
         <label><input type="radio" name="q2" value="b"> Viscosity rating, specific gravity, and contamination level.</label>
         <label><input type="radio" name="q2" value="c"> Type of product, grade (API rating), and viscosity rating (SAE and ISO designation).</label>
         <label><input type="radio" name="q2" value="d"> Core charge, cost, and availability of the synthetic blend.</label>
       </div>
       <div class="question">
-        <p><strong>3. According to Table 1, which lubricant is specified for use in highly loaded gears and hypoid gear applications?</strong></p>
+        <p><strong>According to Table 1, which lubricant is specified for use in highly loaded gears and hypoid gear applications?</strong></p>
         <label><input type="radio" name="q3" value="a"> Heavy-Duty Engine Oil 50</label>
         <label><input type="radio" name="q3" value="b"> Eaton Approved Synthetic Transmission Oil 50</label>
         <label><input type="radio" name="q3" value="c"> API - GL5</label>
         <label><input type="radio" name="q3" value="d"> Automatic Transmission Fluid (ATF)</label>
       </div>
       <div class="question">
-        <p><strong>4. Based on the manufacturer's recommendations provided in Table 1, what critical warning is given regarding the lubricant selection process?</strong></p>
+        <p><strong>Based on the manufacturer's recommendations provided in Table 1, what critical warning is given regarding the lubricant selection process?</strong></p>
         <label><input type="radio" name="q4" value="a"> Always use the highest viscosity available to prevent gear wear.</label>
         <label><input type="radio" name="q4" value="b"> Never use synthetic oils unless the transmission is specifically designed for them.</label>
         <label><input type="radio" name="q4" value="c"> Never mix engine oils and gear oils in the same transmission.</label>
         <label><input type="radio" name="q4" value="d"> Additives and friction modifiers must always be used when operating below −12 °C (10 °F).</label>
       </div>
       <div class="question">
-        <p><strong>5. The most common lubrication method used on all transmissions is the splash lubrication system. How does this system ensure the upper components, such as the mainshaft and upper countershafts, receive oil?</strong></p>
+        <p><strong>The most common lubrication method used on all transmissions is the splash lubrication system. How does this system ensure the upper components, such as the mainshaft and upper countershafts, receive oil?</strong></p>
         <label><input type="radio" name="q5" value="a"> Oil galleries pump oil directly to the mainshaft assembly.</label>
         <label><input type="radio" name="q5" value="b"> The oil pump sends pressurized oil through internal passages.</label>
         <label><input type="radio" name="q5" value="c"> The countershafts rotate, carrying oil to other countershafts and splashing oil onto the mainshaft assembly.</label>
         <label><input type="radio" name="q5" value="d"> Bolt-on troughs collect oil and deliver it via gravity feed.</label>
       </div>
       <div class="question">
-        <p><strong>6. To ensure oil is directed to critical internal areas, such as the roller bearing on the reverse idler shaft, the transmission housing often includes what physical feature?</strong></p>
+        <p><strong>To ensure oil is directed to critical internal areas, such as the roller bearing on the reverse idler shaft, the transmission housing often includes what physical feature?</strong></p>
         <label><input type="radio" name="q6" value="a"> Internal oil pressure passages connected to the main oil pump.</label>
         <label><input type="radio" name="q6" value="b"> Galleries and collection reservoirs cast into the housing.</label>
         <label><input type="radio" name="q6" value="c"> Dedicated external lubrication lines and fittings.</label>
         <label><input type="radio" name="q6" value="d"> Specialized mainshaft gear sleeves with oil holes.</label>
       </div>
       <div class="question">
-        <p><strong>7. In a heavy-duty transmission, what component is often bolted to the shift bar housing to direct oil thrown from the splashing system to critical areas?</strong></p>
+        <p><strong>In a heavy-duty transmission, what component is often bolted to the shift bar housing to direct oil thrown from the splashing system to critical areas?</strong></p>
         <label><input type="radio" name="q7" value="a"> A filter mesh strainer</label>
         <label><input type="radio" name="q7" value="b"> A bolt-on oil trough</label>
         <label><input type="radio" name="q7" value="c"> A magnetic drain plug</label>
         <label><input type="radio" name="q7" value="d"> The shift rail interlock pin</label>
       </div>
       <div class="question">
-        <p><strong>8. In some transmissions, a pressure type lubrication system is incorporated alongside the splash system. Where is the small eccentric shuttle type oil pump typically located?</strong></p>
+        <p><strong>In some transmissions, a pressure type lubrication system is incorporated alongside the splash system. Where is the small eccentric shuttle type oil pump typically located?</strong></p>
         <label><input type="radio" name="q8" value="a"> In the bottom of the oil reservoir, near the drain plug.</label>
         <label><input type="radio" name="q8" value="b"> Clamped or bolted to the end of the auxiliary countershaft.</label>
         <label><input type="radio" name="q8" value="c"> In the transmission input shaft.</label>
         <label><input type="radio" name="q8" value="d"> Mounted externally on the transmission PTO opening.</label>
       </div>
       <div class="question">
-        <p><strong>9. In the oil pump system illustrated in Figure 4, if the oil trough or the oil supply passage in the transmission housing becomes plugged, what is the consequence for the synchronizer assembly?</strong></p>
+        <p><strong>In the oil pump system illustrated in Figure 4, if the oil trough or the oil supply passage in the transmission housing becomes plugged, what is the consequence for the synchronizer assembly?</strong></p>
         <label><input type="radio" name="q9" value="a"> The mainshaft gear will freewheel, allowing a neutral shift.</label>
         <label><input type="radio" name="q9" value="b"> The oil pump will not operate, reducing synchronizer assembly service life due to inadequate lubrication.</label>
         <label><input type="radio" name="q9" value="c"> The relief valve opens, forcing oil into the oil cooler lines.</label>
         <label><input type="radio" name="q9" value="d"> The sliding clutch will lock the mainshaft gear to the countershaft.</label>
       </div>
       <div class="question">
-        <p><strong>10. What drives the integral oil pump (Figure 5) used to send oil to a cooler in heavy-duty transmissions?</strong></p>
+        <p><strong>What drives the integral oil pump (Figure 5) used to send oil to a cooler in heavy-duty transmissions?</strong></p>
         <label><input type="radio" name="q10" value="a"> The rotation of the mainshaft gear.</label>
         <label><input type="radio" name="q10" value="b"> The shifting action of the shift rails.</label>
         <label><input type="radio" name="q10" value="c"> A PTO gear, driving it any time the input shaft is turning.</label>
         <label><input type="radio" name="q10" value="d"> A dedicated electric motor controlled by a temperature sensor.</label>
       </div>
       <div class="question">
-        <p><strong>11. What action occurs if the oil cooler lines are plugged on a transmission utilizing an integral oil pump with a relief valve?</strong></p>
+        <p><strong>What action occurs if the oil cooler lines are plugged on a transmission utilizing an integral oil pump with a relief valve?</strong></p>
         <label><input type="radio" name="q11" value="a"> The synchronizer assembly automatically disengages.</label>
         <label><input type="radio" name="q11" value="b"> The clutch brake engages to stop the countershaft rotation.</label>
         <label><input type="radio" name="q11" value="c"> The oil will be forced to go over the relief valve, increasing heat rather than getting rid of it.</label>
         <label><input type="radio" name="q11" value="d"> The oil gallery in the mainshaft opens to bypass the pump entirely.</label>
       </div>
       <div class="question">
-        <p><strong>12. Heavy-duty transmissions that rely on splash lubrication typically filter oil by means of:</strong></p>
+        <p><strong>Heavy-duty transmissions that rely on splash lubrication typically filter oil by means of:</strong></p>
         <label><input type="radio" name="q12" value="a"> An optional filter installed between the pump outlet and the cooler.</label>
         <label><input type="radio" name="q12" value="b"> Magnetic drain plugs or magnets located in the bottom of the transmission case.</label>
         <label><input type="radio" name="q12" value="c"> A mesh strainer located at the output shaft.</label>
         <label><input type="radio" name="q12" value="d"> A pressurized return line leading to a dedicated external filter.</label>
       </div>
       <div class="question">
-        <p><strong>13. When a pressure pump system is used, what additional component is utilized on the suction tube to assist the magnets in trapping foreign material in the oil?</strong></p>
+        <p><strong>When a pressure pump system is used, what additional component is utilized on the suction tube to assist the magnets in trapping foreign material in the oil?</strong></p>
         <label><input type="radio" name="q13" value="a"> A secondary magnetic plug</label>
         <label><input type="radio" name="q13" value="b"> A check valve</label>
         <label><input type="radio" name="q13" value="c"> Mesh strainers</label>
         <label><input type="radio" name="q13" value="d"> A bypass filter</label>
       </div>
       <div class="question">
-        <p><strong>14. What common component, used as part of the integral oil pump system (Figure 5), is employed to clean the oil of metal particles?</strong></p>
+        <p><strong>What common component, used as part of the integral oil pump system (Figure 5), is employed to clean the oil of metal particles?</strong></p>
         <label><input type="radio" name="q14" value="a"> Magnet</label>
         <label><input type="radio" name="q14" value="b"> Suction tube</label>
         <label><input type="radio" name="q14" value="c"> Element filter</label>
         <label><input type="radio" name="q14" value="d"> Relief Valve</label>
       </div>
       <div class="question">
-        <p><strong>15. If a transmission is not equipped with an internal oil pump, an optional externally mounted pump may be used. Where does this external pump typically receive its oil supply?</strong></p>
+        <p><strong>If a transmission is not equipped with an internal oil pump, an optional externally mounted pump may be used. Where does this external pump typically receive its oil supply?</strong></p>
         <label><input type="radio" name="q15" value="a"> From the top of the mainshaft assembly.</label>
         <label><input type="radio" name="q15" value="b"> From the input shaft oil gallery.</label>
         <label><input type="radio" name="q15" value="c"> Through an adapter mounted in the drain plug hole.</label>
         <label><input type="radio" name="q15" value="d"> Directly from the clutch housing reservoir.</label>
       </div>
       <div class="question">
-        <p><strong>16. What is the definition of an auxiliary drive system, such as a power takeoff (PTO)?</strong></p>
+        <p><strong>What is the definition of an auxiliary drive system, such as a power takeoff (PTO)?</strong></p>
         <label><input type="radio" name="q16" value="a"> A transfer case component that distributes power to the front and rear axles.</label>
         <label><input type="radio" name="q16" value="b"> A system that transmits power from an engine, transmission, auxiliary transmission, or transfer case to equipment requiring rotating power.</label>
         <label><input type="radio" name="q16" value="c"> A specialized hydraulic pump mounted on the crankshaft.</label>
         <label><input type="radio" name="q16" value="d"> A driveline stabilizer that reduces torsional vibration.</label>
       </div>
       <div class="question">
-        <p><strong>17. Which types of auxiliary drive systems are always driving whenever the engine is turning?</strong></p>
+        <p><strong>Which types of auxiliary drive systems are always driving whenever the engine is turning?</strong></p>
         <label><input type="radio" name="q17" value="a"> Transmission-mounted power takeoff and transfer case mounted PTO.</label>
         <label><input type="radio" name="q17" value="b"> Drop box and auxiliary transmission mounted PTO.</label>
         <label><input type="radio" name="q17" value="c"> Front engine mounted and rear engine mounted auxiliary drives.</label>
         <label><input type="radio" name="q17" value="d"> Cable actuated and electrically actuated PTOs.</label>
       </div>
       <div class="question">
-        <p><strong>18. What is the disadvantage of a rear engine-mounted auxiliary drive connected to the flywheel housing?</strong></p>
+        <p><strong>What is the disadvantage of a rear engine-mounted auxiliary drive connected to the flywheel housing?</strong></p>
         <label><input type="radio" name="q18" value="a"> It requires complex cable actuation to engage.</label>
         <label><input type="radio" name="q18" value="b"> It is always driving whenever the engine is running.</label>
         <label><input type="radio" name="q18" value="c"> It requires the use of helical gears to handle the torque.</label>
         <label><input type="radio" name="q18" value="d"> It can only be used with multiple countershaft transmissions.</label>
       </div>
       <div class="question">
-        <p><strong>19. A power tower auxiliary drive unit is commonly used on oilfield trucks to drive heavy-duty winches. To what component is this unit typically bolted?</strong></p>
+        <p><strong>A power tower auxiliary drive unit is commonly used on oilfield trucks to drive heavy-duty winches. To what component is this unit typically bolted?</strong></p>
         <label><input type="radio" name="q19" value="a"> The main transmission input shaft.</label>
         <label><input type="radio" name="q19" value="b"> The top of the twin countershaft auxiliary transmission.</label>
         <label><input type="radio" name="q19" value="c"> The rear PTO adapter housing.</label>
         <label><input type="radio" name="q19" value="d"> The differential carrier assembly.</label>
       </div>
       <div class="question">
-        <p><strong>20. What enables the operator to vary the speed and torque output of an auxiliary transmission top-mounted power takeoff (power tower)?</strong></p>
+        <p><strong>What enables the operator to vary the speed and torque output of an auxiliary transmission top-mounted power takeoff (power tower)?</strong></p>
         <label><input type="radio" name="q20" value="a"> The ability to use the range cylinder to select high or low range.</label>
         <label><input type="radio" name="q20" value="b"> Shifting the main transmission through its gears while the auxiliary transmission is put in neutral.</label>
         <label><input type="radio" name="q20" value="c"> Changing the ratio of the output shaft gears via an external switch.</label>
         <label><input type="radio" name="q20" value="d"> Engaging the clutch brake to reduce the countershaft speed.</label>
       </div>
       <div class="question">
-        <p><strong>21. Auxiliary PTO bolt-on units are available in two specific mounting configurations. What are they?</strong></p>
+        <p><strong>Auxiliary PTO bolt-on units are available in two specific mounting configurations. What are they?</strong></p>
         <label><input type="radio" name="q21" value="a"> 4-bolt or 6-bolt mounted.</label>
         <label><input type="radio" name="q21" value="b"> 6-bolt or 8-bolt mounted.</label>
         <label><input type="radio" name="q21" value="c"> Single-speed or multiple-speed mounted.</label>
         <label><input type="radio" name="q21" value="d"> Top-mounted or bottom-mounted.</label>
       </div>
       <div class="question">
-        <p><strong>22. A drop box differs from a transfer case in its primary function because the drop box:</strong></p>
+        <p><strong>A drop box differs from a transfer case in its primary function because the drop box:</strong></p>
         <label><input type="radio" name="q22" value="a"> Always provides a large ratio change (reduction).</label>
         <label><input type="radio" name="q22" value="b"> Drives some auxiliary function rather than another drive axle.</label>
         <label><input type="radio" name="q22" value="c"> Is mounted to the front of the crankshaft.</label>
         <label><input type="radio" name="q22" value="d"> Requires the use of hydraulic actuation.</label>
       </div>
       <div class="question">
-        <p><strong>23. Which accessory drive system is used when large amounts of torque are required, and the main transmission must be in a gear to deliver the necessary speed and torque?</strong></p>
+        <p><strong>Which accessory drive system is used when large amounts of torque are required, and the main transmission must be in a gear to deliver the necessary speed and torque?</strong></p>
         <label><input type="radio" name="q23" value="a"> Rear engine-mounted drive.</label>
         <label><input type="radio" name="q23" value="b"> Front engine-mounted hydraulic pump.</label>
         <label><input type="radio" name="q23" value="c"> Power takeoff (PTO) output shaft on a transfer case.</label>
         <label><input type="radio" name="q23" value="d"> Electric solenoid actuated PTO.</label>
       </div>
       <div class="question">
-        <p><strong>24. PTO output drive shafts constructed of tubular material are designed specifically for which applications?</strong></p>
+        <p><strong>PTO output drive shafts constructed of tubular material are designed specifically for which applications?</strong></p>
         <label><input type="radio" name="q24" value="a"> Low torque or low speed applications.</label>
         <label><input type="radio" name="q24" value="b"> High torque or rpm applications.</label>
         <label><input type="radio" name="q24" value="c"> Clutch shift actuated systems only.</label>
         <label><input type="radio" name="q24" value="d"> Systems requiring only solid round shafting.</label>
       </div>
       <div class="question">
-        <p><strong>25. The power flow through a PTO may include one to three gears before driving the output shaft. What is the consequence each time a gear is added to the PTO power flow?</strong></p>
+        <p><strong>The power flow through a PTO may include one to three gears before driving the output shaft. What is the consequence each time a gear is added to the PTO power flow?</strong></p>
         <label><input type="radio" name="q25" value="a"> The torque output is reduced.</label>
         <label><input type="radio" name="q25" value="b"> The speed of rotation is increased.</label>
         <label><input type="radio" name="q25" value="c"> The direction of rotation is reversed.</label>
         <label><input type="radio" name="q25" value="d"> The gear clash risk is increased.</label>
       </div>
       <div class="question">
-        <p><strong>26. What critical safety step must the operator ensure before engaging a power takeoff unit?</strong></p>
+        <p><strong>What critical safety step must the operator ensure before engaging a power takeoff unit?</strong></p>
         <label><input type="radio" name="q26" value="a"> That the vehicle speed is below 5 mph.</label>
         <label><input type="radio" name="q26" value="b"> That the PTO indicator light is illuminated.</label>
         <label><input type="radio" name="q26" value="c"> That the clutch is disengaged and the transmission gears are not turning.</label>
         <label><input type="radio" name="q26" value="d"> That the shift rail is locked by the interlock pin.</label>
       </div>
       <div class="question">
-        <p><strong>27. Engaging the PTO while the transmission gears are still turning will result in:</strong></p>
+        <p><strong>Engaging the PTO while the transmission gears are still turning will result in:</strong></p>
         <label><input type="radio" name="q27" value="a"> Increased stress on the driveline shaft.</label>
         <label><input type="radio" name="q27" value="b"> The clutch shift friction disks overheating.</label>
         <label><input type="radio" name="q27" value="c"> Gear clashing and damage to the engaging teeth.</label>
         <label><input type="radio" name="q27" value="d"> Activation of the torque-limiting clutch brake.</label>
       </div>
       <div class="question">
-        <p><strong>28. The cable actuated PTO system is essentially what type of mechanism?</strong></p>
+        <p><strong>The cable actuated PTO system is essentially what type of mechanism?</strong></p>
         <label><input type="radio" name="q28" value="a"> Hydraulic pressure application system.</label>
         <label><input type="radio" name="q28" value="b"> Rotary motion solenoid system.</label>
         <label><input type="radio" name="q28" value="c"> A push-pull type of activation system.</label>
         <label><input type="radio" name="q28" value="d"> A mechanical linkage and control rod system.</label>
       </div>
       <div class="question">
-        <p><strong>29. On heavy trucks equipped with compressed air for the braking system, the PTO may be activated using air to move which specific component?</strong></p>
+        <p><strong>On heavy trucks equipped with compressed air for the braking system, the PTO may be activated using air to move which specific component?</strong></p>
         <label><input type="radio" name="q29" value="a"> The solenoid.</label>
         <label><input type="radio" name="q29" value="b"> The Air Shift Cylinder.</label>
         <label><input type="radio" name="q29" value="c"> The shift rod and fork assembly.</label>
         <label><input type="radio" name="q29" value="d"> The engagement switch indicator light.</label>
       </div>
       <div class="question">
-        <p><strong>30. What is the primary functional advantage of a Clutch Shift Actuated PTO (also called power shift or hot shift)?</strong></p>
+        <p><strong>What is the primary functional advantage of a Clutch Shift Actuated PTO (also called power shift or hot shift)?</strong></p>
         <label><input type="radio" name="q30" value="a"> It uses simpler sliding gears, reducing cost.</label>
         <label><input type="radio" name="q30" value="b"> It may be safely engaged and disengaged with the vehicle in motion.</label>
         <label><input type="radio" name="q30" value="c"> It requires less lubrication than a sliding gear PTO.</label>
         <label><input type="radio" name="q30" value="d"> It uses a normally closed indicator switch for operation.</label>
       </div>
       <div class="question">
-        <p><strong>31. How do Clutch Shift PTOs achieve engagement, unlike traditional PTOs that use sliding gears?</strong></p>
+        <p><strong>How do Clutch Shift PTOs achieve engagement, unlike traditional PTOs that use sliding gears?</strong></p>
         <label><input type="radio" name="q31" value="a"> Through mechanical linkage and detent balls.</label>
         <label><input type="radio" name="q31" value="b"> By electrical solenoid operation controlled by the dash switch.</label>
         <label><input type="radio" name="q31" value="c"> By means of friction disks, much like those used in automatic transmissions.</label>
         <label><input type="radio" name="q31" value="d"> By utilizing a fluid coupling device.</label>
       </div>
       <div class="question">
-        <p><strong>32. The Indicator Switch used in most PTO systems serves what purpose?</strong></p>
+        <p><strong>The Indicator Switch used in most PTO systems serves what purpose?</strong></p>
         <label><input type="radio" name="q32" value="a"> To control the electric solenoid that moves the shift rod.</label>
         <label><input type="radio" name="q32" value="b"> To interrupt the power flow if the transmission speed is too high.</label>
         <label><input type="radio" name="q32" value="c"> To let the operator know whether the PTO is in the engaged position.</label>
         <label><input type="radio" name="q32" value="d"> To manually open the oil relief valve.</label>
       </div>
       <div class="question">
-        <p><strong>33. When a single gear adapter housing is sold to a customer to facilitate PTO installation due to obstructions, what critical functional change must the parts technician remind the customer about?</strong></p>
+        <p><strong>When a single gear adapter housing is sold to a customer to facilitate PTO installation due to obstructions, what critical functional change must the parts technician remind the customer about?</strong></p>
         <label><input type="radio" name="q33" value="a"> The need for four gaskets to prevent leaks.</label>
         <label><input type="radio" name="q33" value="b"> The requirement for a filler block instead of an adapter plate.</label>
         <label><input type="radio" name="q33" value="c"> A single gear adapter will change the rotation of the output shaft.</label>
         <label><input type="radio" name="q33" value="d"> The adapter housing eliminates the need for backlash adjustment.</label>
       </div>
       <div class="question">
-        <p><strong>34. Power takeoffs generally receive lubrication from the major component to which they are attached. What is the procedural consequence once the PTO is installed?</strong></p>
+        <p><strong>Power takeoffs generally receive lubrication from the major component to which they are attached. What is the procedural consequence once the PTO is installed?</strong></p>
         <label><input type="radio" name="q34" value="a"> The PTO should be filled with synthetic gear oil before operation.</label>
         <label><input type="radio" name="q34" value="b"> The major component requires an additional amount of lubricant.</label>
         <label><input type="radio" name="q34" value="c"> The PTO must be filled with engine oil to prevent seal damage.</label>
         <label><input type="radio" name="q34" value="d"> The oil trough bolted to the shift bar housing must be removed.</label>
       </div>
       <div class="question">
-        <p><strong>35. The gasket installed between the PTO and the transmission provides which two essential functions?</strong></p>
+        <p><strong>The gasket installed between the PTO and the transmission provides which two essential functions?</strong></p>
         <label><input type="radio" name="q35" value="a"> It acts as a friction disk and adjusts gear speed.</label>
         <label><input type="radio" name="q35" value="b"> It prevents wear between the mating surfaces and absorbs vibration.</label>
         <label><input type="radio" name="q35" value="c"> It acts as a seal to keep lubrication from leaking and provides a way of setting the proper backlash.</label>
         <label><input type="radio" name="q35" value="d"> It supports the driveline yoke and reduces gear noise.</label>
       </div>
       <div class="question">
-        <p><strong>36. What is the maximum number of gaskets recommended to be installed between the PTO and the transmission mounting surfaces?</strong></p>
+        <p><strong>What is the maximum number of gaskets recommended to be installed between the PTO and the transmission mounting surfaces?</strong></p>
         <label><input type="radio" name="q36" value="a"> Two</label>
         <label><input type="radio" name="q36" value="b"> Three</label>
         <label><input type="radio" name="q36" value="c"> Four</label>
         <label><input type="radio" name="q36" value="d"> Six</label>
       </div>
       <div class="question">
-        <p><strong>37. If more than four gaskets are required to achieve the proper backlash during PTO installation, what replacement component must be used instead?</strong></p>
+        <p><strong>If more than four gaskets are required to achieve the proper backlash during PTO installation, what replacement component must be used instead?</strong></p>
         <label><input type="radio" name="q37" value="a"> A six-bolt PTO adapter plate.</label>
         <label><input type="radio" name="q37" value="b"> A special filler block.</label>
         <label><input type="radio" name="q37" value="c"> A clutch shift actuated PTO.</label>
         <label><input type="radio" name="q37" value="d"> A new main transmission housing.</label>
       </div>
       <div class="question">
-        <p><strong>38. The process of setting the proper backlash using selective thickness gaskets is necessary to provide what feature in the meshing gears?</strong></p>
+        <p><strong>The process of setting the proper backlash using selective thickness gaskets is necessary to provide what feature in the meshing gears?</strong></p>
         <label><input type="radio" name="q38" value="a"> Alignment</label>
         <label><input type="radio" name="q38" value="b"> Lubrication flow</label>
         <label><input type="radio" name="q38" value="c"> Clearance between the teeth required for heat expansion.</label>
         <label><input type="radio" name="q38" value="d"> Torsional dampening</label>
       </div>
       <div class="question">
-        <p><strong>39. To adapt a six-bolt PTO to an eight-bolt opening so that it may be installed in a different location, what component is required?</strong></p>
+        <p><strong>To adapt a six-bolt PTO to an eight-bolt opening so that it may be installed in a different location, what component is required?</strong></p>
         <label><input type="radio" name="q39" value="a"> A special filler block.</label>
         <label><input type="radio" name="q39" value="b"> An auxiliary oil pump assembly.</label>
         <label><input type="radio" name="q39" value="c"> An adapter plate.</label>
         <label><input type="radio" name="q39" value="d"> A seven-speed auxiliary transmission.</label>
       </div>
       <div class="question">
-        <p><strong>40. When an adapter plate is used to mount a PTO, how many gaskets are required at minimum?</strong></p>
+        <p><strong>When an adapter plate is used to mount a PTO, how many gaskets are required at minimum?</strong></p>
         <label><input type="radio" name="q40" value="a"> None, because the adapter plate includes an integrated seal.</label>
         <label><input type="radio" name="q40" value="b"> One gasket between the PTO and the transmission.</label>
         <label><input type="radio" name="q40" value="c"> At least one gasket between the PTO and the plate and one between the plate and the transmission.</label>
         <label><input type="radio" name="q40" value="d"> Four gaskets total to ensure adequate sealing.</label>
       </div>
       <div class="question">
-        <p><strong>41. When a transmission is opened for repair, what essential maintenance consideration should a parts technician remind a customer about, regarding low-cost components that ensure a trouble-free repair?</strong></p>
+        <p><strong>When a transmission is opened for repair, what essential maintenance consideration should a parts technician remind a customer about, regarding low-cost components that ensure a trouble-free repair?</strong></p>
         <label><input type="radio" name="q41" value="a"> Upgrading to a clutch shift PTO.</label>
         <label><input type="radio" name="q41" value="b"> Replacing only the damaged shafts or gears.</label>
         <label><input type="radio" name="q41" value="c"> Replacing bearings, O-rings, seals, and gaskets.</label>
         <label><input type="radio" name="q41" value="d"> Installing a mesh strainer on the input shaft.</label>
       </div>
       <div class="question">
-        <p><strong>42. If a customer is replacing a failed transmission shaft, which related sales items should the technician recommend, according to Table 2?</strong></p>
+        <p><strong>If a customer is replacing a failed transmission shaft, which related sales items should the technician recommend, according to Table 2?</strong></p>
         <label><input type="radio" name="q42" value="a"> Only the gears and clutch assembly.</label>
         <label><input type="radio" name="q42" value="b"> Lubrication hoses and air line fittings.</label>
         <label><input type="radio" name="q42" value="c"> Gears, bearings/bushings, spacers/thrust washers (selective), seals, gaskets, and lubricant.</label>
         <label><input type="radio" name="q42" value="d"> Only the PTO U-joint and steady bearing.</label>
       </div>
       <div class="question">
-        <p><strong>43. Which specific components in the list of common PTO replacement parts require special care and attention because they are susceptible to wear and leakage?</strong></p>
+        <p><strong>Which specific components in the list of common PTO replacement parts require special care and attention because they are susceptible to wear and leakage?</strong></p>
         <label><input type="radio" name="q43" value="a"> Driveline U-joints.</label>
         <label><input type="radio" name="q43" value="b"> O-rings and seals (especially output shaft).</label>
         <label><input type="radio" name="q43" value="c"> PTO gears and bearings.</label>
         <label><input type="radio" name="q43" value="d"> Clutch shift friction disks.</label>
       </div>
       <div class="question">
-        <p><strong>44. When a U-joint fails in a PTO driveline system, which related components should the parts technician suggest to the customer as necessary replacement items (Table 3)?</strong></p>
+        <p><strong>When a U-joint fails in a PTO driveline system, which related components should the parts technician suggest to the customer as necessary replacement items (Table 3)?</strong></p>
         <label><input type="radio" name="q44" value="a"> PTO bearings and gaskets.</label>
         <label><input type="radio" name="q44" value="b"> Driveline shaft, yoke, and steady bearing.</label>
         <label><input type="radio" name="q44" value="c"> Clutch brake and pilot bearing.</label>
         <label><input type="radio" name="q44" value="d"> Air shift cylinder and indicator switch.</label>
       </div>
       <div class="question">
-        <p><strong>45. Why must a parts technician provide the model number from the PTO tag when ordering replacement parts for a PTO assembly?</strong></p>
+        <p><strong>Why must a parts technician provide the model number from the PTO tag when ordering replacement parts for a PTO assembly?</strong></p>
         <label><input type="radio" name="q45" value="a"> The PTO model number dictates the mounting bolt pattern (6 or 8 bolt).</label>
         <label><input type="radio" name="q45" value="b"> PTOs are specialty items and parts are not readily available, requiring specific supplier identification.</label>
         <label><input type="radio" name="q45" value="c"> The model number determines whether the PTO is cable or air actuated.</label>
         <label><input type="radio" name="q45" value="d"> The model number indicates the required fluid viscosity rating.</label>
       </div>
       <div class="question">
-        <p><strong>46. What type of PTO output shaft material is used in standard applications not requiring extremely high torque or RPM?</strong></p>
+        <p><strong>What type of PTO output shaft material is used in standard applications not requiring extremely high torque or RPM?</strong></p>
         <label><input type="radio" name="q46" value="a"> Tubular material</label>
         <label><input type="radio" name="q46" value="b"> Solid round, square or hexagon material</label>
         <label><input type="radio" name="q46" value="c"> Ceramic material</label>
         <label><input type="radio" name="q46" value="d"> Multi-disc friction material</label>
       </div>
       <div class="question">
-        <p><strong>47. In the context of core management for remanufactured transmissions, if a customer returns a core that requires tear down and inspection, what must the parts technician provide?</strong></p>
+        <p><strong>In the context of core management for remanufactured transmissions, if a customer returns a core that requires tear down and inspection, what must the parts technician provide?</strong></p>
         <label><input type="radio" name="q47" value="a"> An immediate credit equivalent to a "clean core."</label>
         <label><input type="radio" name="q47" value="b"> An invoice for the core inspection fee.</label>
         <label><input type="radio" name="q47" value="c"> A receipt, followed by a credit once the inspection is completed.</label>
         <label><input type="radio" name="q47" value="d"> A mandatory new transmission overhaul kit.</label>
       </div>
       <div class="question">
-        <p><strong>48. What is the fundamental purpose of the core charge system used for remanufactured components?</strong></p>
+        <p><strong>What is the fundamental purpose of the core charge system used for remanufactured components?</strong></p>
         <label><input type="radio" name="q48" value="a"> To ensure the customer pays the full cost upfront.</label>
         <label><input type="radio" name="q48" value="b"> To maintain accurate inventory records of new transmissions.</label>
         <label><input type="radio" name="q48" value="c"> To encourage the customer to return a rebuildable core.</label>
         <label><input type="radio" name="q48" value="d"> To cover the cost of the magnetic drain plug replacements.</label>
       </div>
       <div class="question">
-        <p><strong>49. When the transmission uses the pressure type lubrication system, the oil is typically supplied to the pump via which component?</strong></p>
+        <p><strong>When the transmission uses the pressure type lubrication system, the oil is typically supplied to the pump via which component?</strong></p>
         <label><input type="radio" name="q49" value="a"> The main bearing retainer.</label>
         <label><input type="radio" name="q49" value="b"> A trough cast into the inside of the transmission housing.</label>
         <label><input type="radio" name="q49" value="c"> An external hose connected to the engine oil system.</label>
         <label><input type="radio" name="q49" value="d"> The auxiliary drive output shaft.</label>
       </div>
       <div class="question">
-        <p><strong>50. What type of lubricant is typically recommended for use in transmissions when the ambient temperature is below −12 °C (10 °F), according to Table 1?</strong></p>
+        <p><strong>What type of lubricant is typically recommended for use in transmissions when the ambient temperature is below −12 °C (10 °F), according to Table 1?</strong></p>
         <label><input type="radio" name="q50" value="a"> Heavy-Duty Engine Oil 50</label>
         <label><input type="radio" name="q50" value="b"> Heavy-Duty Engine Oil 30 or API MT-1 75W</label>
         <label><input type="radio" name="q50" value="c"> Automotive Gear Oil 80-90</label>

--- a/270202-test/270202f - Drivelines.html
+++ b/270202-test/270202f - Drivelines.html
@@ -72,7 +72,7 @@
 
 
       <div class="question">
-        <p><strong>1. What is the normal maximum working drive angle recommended for a conventional cross-and-roller universal joint (U-joint)?</strong></p>
+        <p><strong>What is the normal maximum working drive angle recommended for a conventional cross-and-roller universal joint (U-joint)?</strong></p>
         <label><input type="radio" name="q1" value="a"> 5 °</label>
         <label><input type="radio" name="q1" value="b"> 10 °</label>
         <label><input type="radio" name="q1" value="c"> 12 ° </label>
@@ -81,7 +81,7 @@
 
 
       <div class="question">
-        <p><strong>2. A driveshaft is manufactured to close tolerances at the factory. What is the maximum permitted tolerance (or &quot;true to&quot;) for driveshaft balance?</strong></p>
+        <p><strong>A driveshaft is manufactured to close tolerances at the factory. What is the maximum permitted tolerance (or &quot;true to&quot;) for driveshaft balance?</strong></p>
         <label><input type="radio" name="q2" value="a"> 0.001 inches (0.025 mm)</label>
         <label><input type="radio" name="q2" value="b"> 0.01 inches (0.25 mm)</label>
         <label><input type="radio" name="q2" value="c"> 0.1 inches (2.5 mm)</label>
@@ -90,7 +90,7 @@
 
 
       <div class="question">
-        <p><strong>3. During one full revolution of a driveshaft utilizing conventional U-joints, how many times does the driveshaft speed up and slow down?</strong></p>
+        <p><strong>During one full revolution of a driveshaft utilizing conventional U-joints, how many times does the driveshaft speed up and slow down?</strong></p>
         <label><input type="radio" name="q3" value="a"> The speed is constant throughout the revolution.</label>
         <label><input type="radio" name="q3" value="b"> Speeds up once and slows down once.</label>
         <label><input type="radio" name="q3" value="c"> Speeds up twice and slows down twice.</label>
@@ -99,7 +99,7 @@
 
 
       <div class="question">
-        <p><strong>4. At how many points through its rotation does the speed of a driveshaft using conventional U-joints match the constant speed of the transmission output shaft?</strong></p>
+        <p><strong>At how many points through its rotation does the speed of a driveshaft using conventional U-joints match the constant speed of the transmission output shaft?</strong></p>
         <label><input type="radio" name="q4" value="a"> Two points</label>
         <label><input type="radio" name="q4" value="b"> Three points</label>
         <label><input type="radio" name="q4" value="c"> Four points, or every 90 °</label>
@@ -108,7 +108,7 @@
 
 
       <div class="question">
-        <p><strong>5. What is the most common type of driveline used in rear-wheel drive cars and light trucks, characterized by an open propeller shaft using a minimum of two universal joints?</strong></p>
+        <p><strong>What is the most common type of driveline used in rear-wheel drive cars and light trucks, characterized by an open propeller shaft using a minimum of two universal joints?</strong></p>
         <label><input type="radio" name="q5" value="a"> Tripod joint driveline</label>
         <label><input type="radio" name="q5" value="b"> Hotchkiss driveline</label>
         <label><input type="radio" name="q5" value="c"> Torque tube arrangement</label>
@@ -117,7 +117,7 @@
 
 
       <div class="question">
-        <p><strong>6. A driveline must be capable of transferring power from a component that is fixed or attached to the chassis to a component that moves with the wheels. To accomplish this, the driveline must be designed to:</strong></p>
+        <p><strong>A driveline must be capable of transferring power from a component that is fixed or attached to the chassis to a component that moves with the wheels. To accomplish this, the driveline must be designed to:</strong></p>
         <label><input type="radio" name="q6" value="a"> Maintain a fixed length and angle.</label>
         <label><input type="radio" name="q6" value="b"> Operate exclusively in Direct Drive (1:1 ratio).</label>
         <label><input type="radio" name="q6" value="c"> Flex and change length.</label>
@@ -126,7 +126,7 @@
 
 
       <div class="question">
-        <p><strong>7. Which component is the part of the driveline that connects a fixed final drive assembly to the moving rear wheels in rear-wheel drive vehicles with independent rear suspension?</strong></p>
+        <p><strong>Which component is the part of the driveline that connects a fixed final drive assembly to the moving rear wheels in rear-wheel drive vehicles with independent rear suspension?</strong></p>
         <label><input type="radio" name="q7" value="a"> The main propeller shaft</label>
         <label><input type="radio" name="q7" value="b"> The centre support bearing</label>
         <label><input type="radio" name="q7" value="c"> The driveshafts (halfshafts)</label>
@@ -135,7 +135,7 @@
 
 
       <div class="question">
-        <p><strong>8. A driveshaft that is too long will tend to flex, vibrate, and place an increased load on the universal joints. This driveshaft design limitation helps determine the allowable limits for which driveline configuration?</strong></p>
+        <p><strong>A driveshaft that is too long will tend to flex, vibrate, and place an increased load on the universal joints. This driveshaft design limitation helps determine the allowable limits for which driveline configuration?</strong></p>
         <label><input type="radio" name="q8" value="a"> Compound shaft assemblies</label>
         <label><input type="radio" name="q8" value="b"> Single Shaft drivelines</label>
         <label><input type="radio" name="q8" value="c"> Front-wheel drive halfshafts</label>
@@ -144,7 +144,7 @@
 
 
       <div class="question">
-        <p><strong>9. When multiple shafts are required due to an extremely long wheelbase, a centre support bearing (midship bearing) must be used. What is the function of this bearing in relation to the driveshafts?</strong></p>
+        <p><strong>When multiple shafts are required due to an extremely long wheelbase, a centre support bearing (midship bearing) must be used. What is the function of this bearing in relation to the driveshafts?</strong></p>
         <label><input type="radio" name="q9" value="a"> It acts as a primary slip joint to allow length change.</label>
         <label><input type="radio" name="q9" value="b"> It carries the weight of the first shaft and secures its position in relation to the next shaft.</label>
         <label><input type="radio" name="q9" value="c"> It transfers power from the final drive assembly to the rear wheels.</label>
@@ -153,7 +153,7 @@
 
 
       <div class="question">
-        <p><strong>10. A centre support bearing assembly is comprised of a sealed ball bearing mounted within what component that is designed to absorb vibration?</strong></p>
+        <p><strong>A centre support bearing assembly is comprised of a sealed ball bearing mounted within what component that is designed to absorb vibration?</strong></p>
         <label><input type="radio" name="q10" value="a"> A steel bracket, bolted directly to the frame.</label>
         <label><input type="radio" name="q10" value="b"> A rigid cast iron housing.</label>
         <label><input type="radio" name="q10" value="c"> A rubber isolator fitted inside a steel bracket.</label>
@@ -162,7 +162,7 @@
 
 
       <div class="question">
-        <p><strong>11. Why is the rubber isolator in a centre support bearing sometimes slotted rather than solid?</strong></p>
+        <p><strong>Why is the rubber isolator in a centre support bearing sometimes slotted rather than solid?</strong></p>
         <label><input type="radio" name="q11" value="a"> The slotted design requires less lubrication.</label>
         <label><input type="radio" name="q11" value="b"> The slotted design is required for two-piece driveshafts only.</label>
         <label><input type="radio" name="q11" value="c"> The slotted isolator cuts down on vibration more than the solid rubber isolator.</label>
@@ -171,7 +171,7 @@
 
 
       <div class="question">
-        <p><strong>12. The most common component replacement on rear-wheel drive vehicles, essential for allowing power transfer at an angle, is the:</strong></p>
+        <p><strong>The most common component replacement on rear-wheel drive vehicles, essential for allowing power transfer at an angle, is the:</strong></p>
         <label><input type="radio" name="q12" value="a"> Centre support bearing.</label>
         <label><input type="radio" name="q12" value="b"> Universal joint.</label>
         <label><input type="radio" name="q12" value="c"> Slip yoke.</label>
@@ -180,7 +180,7 @@
 
 
       <div class="question">
-        <p><strong>13. What is the most common U-joint used in drivelines in most rear-wheel drive and four-wheel drive vehicles?</strong></p>
+        <p><strong>What is the most common U-joint used in drivelines in most rear-wheel drive and four-wheel drive vehicles?</strong></p>
         <label><input type="radio" name="q13" value="a"> Rzeppa Joint</label>
         <label><input type="radio" name="q13" value="b"> Tripod Joint</label>
         <label><input type="radio" name="q13" value="c"> Conventional or cross-and-roller U-joint (Cardan)</label>
@@ -189,7 +189,7 @@
 
 
       <div class="question">
-        <p><strong>14. The yoke and the stub shaft must be aligned precisely with one another before welding occurs to ensure:</strong></p>
+        <p><strong>The yoke and the stub shaft must be aligned precisely with one another before welding occurs to ensure:</strong></p>
         <label><input type="radio" name="q14" value="a"> The driveshaft fits into the transmission output shaft.</label>
         <label><input type="radio" name="q14" value="b"> The driveshaft can be easily balanced after assembly.</label>
         <label><input type="radio" name="q14" value="c"> The driveshaft yokes are phased correctly.</label>
@@ -198,7 +198,7 @@
 
 
       <div class="question">
-        <p><strong>15. What is the consequence if conventional U-joints are installed in a driveshaft assembly without operating at a slight angle?</strong></p>
+        <p><strong>What is the consequence if conventional U-joints are installed in a driveshaft assembly without operating at a slight angle?</strong></p>
         <label><input type="radio" name="q15" value="a"> Excessive end play will be introduced into the mainshaft.</label>
         <label><input type="radio" name="q15" value="b"> The needle bearings will not rotate properly, causing premature wear on the trunnions.</label>
         <label><input type="radio" name="q15" value="c"> The slip yoke will lock onto the output shaft splines.</label>
@@ -207,7 +207,7 @@
 
 
       <div class="question">
-        <p><strong>16. What is the primary purpose of the slip yoke in a single driveshaft rear-wheel drive (RWD) application?</strong></p>
+        <p><strong>What is the primary purpose of the slip yoke in a single driveshaft rear-wheel drive (RWD) application?</strong></p>
         <label><input type="radio" name="q16" value="a"> To secure the driveshaft to the differential pinion yoke.</label>
         <label><input type="radio" name="q16" value="b"> To reduce driveshaft vibration at high speed.</label>
         <label><input type="radio" name="q16" value="c"> To allow the driveshaft to change length as the suspension travels or load changes.</label>
@@ -216,7 +216,7 @@
 
 
       <div class="question">
-        <p><strong>17. How is the internal spline of the slip yoke lubricated?</strong></p>
+        <p><strong>How is the internal spline of the slip yoke lubricated?</strong></p>
         <label><input type="radio" name="q17" value="a"> By synthetic grease applied during installation.</label>
         <label><input type="radio" name="q17" value="b"> By the transmission oil.</label>
         <label><input type="radio" name="q17" value="c"> By the differential fluid.</label>
@@ -225,7 +225,7 @@
 
 
       <div class="question">
-        <p><strong>18. What component is added to some slip yokes to reduce vibration by creating a high inertia damper?</strong></p>
+        <p><strong>What component is added to some slip yokes to reduce vibration by creating a high inertia damper?</strong></p>
         <label><input type="radio" name="q18" value="a"> A flat Delrin washer.</label>
         <label><input type="radio" name="q18" value="b"> A heavy, rubber-mounted weight (inertia ring).</label>
         <label><input type="radio" name="q18" value="c"> An externally splined stub shaft.</label>
@@ -234,7 +234,7 @@
 
 
       <div class="question">
-        <p><strong>19. Which component in a cross-and-roller U-joint is constructed of forged steel with four machined and polished bearing surfaces (arms)?</strong></p>
+        <p><strong>Which component in a cross-and-roller U-joint is constructed of forged steel with four machined and polished bearing surfaces (arms)?</strong></p>
         <label><input type="radio" name="q19" value="a"> The bearing cap</label>
         <label><input type="radio" name="q19" value="b"> The shield</label>
         <label><input type="radio" name="q19" value="c"> The cross or spider (trunnions)</label>
@@ -243,7 +243,7 @@
 
 
       <div class="question">
-        <p><strong>20. Which of the following is NOT one of the common methods listed for retaining a U-joint to a yoke?</strong></p>
+        <p><strong>Which of the following is NOT one of the common methods listed for retaining a U-joint to a yoke?</strong></p>
         <label><input type="radio" name="q20" value="a"> Strap</label>
         <label><input type="radio" name="q20" value="b"> Inside snap ring</label>
         <label><input type="radio" name="q20" value="c"> Wing bearing and cotter pin</label>
@@ -252,7 +252,7 @@
 
 
       <div class="question">
-        <p><strong>21. What component is generally applied to the rear U-joint on a rear-wheel drive vehicle because the U-joint at this location does not need to accommodate driveline length changes?</strong></p>
+        <p><strong>What component is generally applied to the rear U-joint on a rear-wheel drive vehicle because the U-joint at this location does not need to accommodate driveline length changes?</strong></p>
         <label><input type="radio" name="q21" value="a"> Slip Yoke</label>
         <label><input type="radio" name="q21" value="b"> Fixed Yoke</label>
         <label><input type="radio" name="q21" value="c"> Double Cardan CV Joint</label>
@@ -261,7 +261,7 @@
 
 
       <div class="question">
-        <p><strong>22. What design feature is used on a driveshaft slip joint to ensure the slip yoke is always repositioned in the same location on the output shaft every time it is removed and replaced?</strong></p>
+        <p><strong>What design feature is used on a driveshaft slip joint to ensure the slip yoke is always repositioned in the same location on the output shaft every time it is removed and replaced?</strong></p>
         <label><input type="radio" name="q22" value="a"> The external splines are machined smooth.</label>
         <label><input type="radio" name="q22" value="b"> The use of a small indexing pin on the yoke.</label>
         <label><input type="radio" name="q22" value="c"> A master spline composed of one larger flute and a corresponding cut-out.</label>
@@ -270,7 +270,7 @@
 
 
       <div class="question">
-        <p><strong>23. Which component of the driveline is explicitly interchangeable with the term &quot;propeller shaft&quot;?</strong></p>
+        <p><strong>Which component of the driveline is explicitly interchangeable with the term &quot;propeller shaft&quot;?</strong></p>
         <label><input type="radio" name="q23" value="a"> Halfshaft</label>
         <label><input type="radio" name="q23" value="b"> Slip Yoke</label>
         <label><input type="radio" name="q23" value="c"> Driveshaft</label>
@@ -279,7 +279,7 @@
 
 
       <div class="question">
-        <p><strong>24. If a customer installs a new driveshaft and subsequently experiences a vibration, what is the most likely cause related to the installation of the shaft?</strong></p>
+        <p><strong>If a customer installs a new driveshaft and subsequently experiences a vibration, what is the most likely cause related to the installation of the shaft?</strong></p>
         <label><input type="radio" name="q24" value="a"> The driveshaft was manufactured with incorrect balance weights.</label>
         <label><input type="radio" name="q24" value="b"> The customer failed to grease the slip yoke splines.</label>
         <label><input type="radio" name="q24" value="c"> The driveshaft yokes were incorrectly phased at the slip joint.</label>
@@ -288,7 +288,7 @@
 
 
       <div class="question">
-        <p><strong>25. The purpose of using two-piece Hotchkiss propeller shafts in long wheelbase vehicles is primarily to:</strong></p>
+        <p><strong>The purpose of using two-piece Hotchkiss propeller shafts in long wheelbase vehicles is primarily to:</strong></p>
         <label><input type="radio" name="q25" value="a"> Increase the drive angle to 40 ° .</label>
         <label><input type="radio" name="q25" value="b"> Reduce driveshaft length (to reduce vibration) and improve ground clearance.</label>
         <label><input type="radio" name="q25" value="c"> Eliminate the need for universal joints entirely.</label>
@@ -297,7 +297,7 @@
 
 
       <div class="question">
-        <p><strong>26. Which type of drive assembly usually requires the driveline to transfer power from a fixed transaxle to moving front wheels?</strong></p>
+        <p><strong>Which type of drive assembly usually requires the driveline to transfer power from a fixed transaxle to moving front wheels?</strong></p>
         <label><input type="radio" name="q26" value="a"> All-Wheel Drive (AWD) with fixed final drives.</label>
         <label><input type="radio" name="q26" value="b"> Hotchkiss rear-wheel drive.</label>
         <label><input type="radio" name="q26" value="c"> Front-Wheel Drive (FWD).</label>
@@ -306,7 +306,7 @@
 
 
       <div class="question">
-        <p><strong>27. A special problem experienced by FWD vehicles, known as torque steer, is caused by which two primary conditions when the transaxle is not centered?</strong></p>
+        <p><strong>A special problem experienced by FWD vehicles, known as torque steer, is caused by which two primary conditions when the transaxle is not centered?</strong></p>
         <label><input type="radio" name="q27" value="a"> Incorrect U-joint phasing and excessive driveshaft vibration.</label>
         <label><input type="radio" name="q27" value="b"> Unequal-length halfshafts causing unequal torque distribution, and shafts operating at different CV joint angles.</label>
         <label><input type="radio" name="q27" value="c"> Failure of the steady bearing and excessive axle end play.</label>
@@ -315,7 +315,7 @@
 
 
       <div class="question">
-        <p><strong>28. In FWD applications, torque steer is commonly corrected by the manufacturer by:</strong></p>
+        <p><strong>In FWD applications, torque steer is commonly corrected by the manufacturer by:</strong></p>
         <label><input type="radio" name="q28" value="a"> Increasing the size of the inner plunge joint.</label>
         <label><input type="radio" name="q28" value="b"> Using a two-piece driveshaft (intermediate shaft) on the long side to equalize halfshaft length.</label>
         <label><input type="radio" name="q28" value="c"> Reducing the size of the transaxle housing.</label>
@@ -324,7 +324,7 @@
 
 
       <div class="question">
-        <p><strong>29. What type of CV joint is designed to allow torque transfer through very sharp angles, specifically up to 40 ° , with reduced noise and vibration?</strong></p>
+        <p><strong>What type of CV joint is designed to allow torque transfer through very sharp angles, specifically up to 40 ° , with reduced noise and vibration?</strong></p>
         <label><input type="radio" name="q29" value="a"> Double Cardan CV Joint</label>
         <label><input type="radio" name="q29" value="b"> Constant Velocity (CV) U-Joints</label>
         <label><input type="radio" name="q29" value="c"> Conventional Cardan U-Joints</label>
@@ -333,7 +333,7 @@
 
 
       <div class="question">
-        <p><strong>30. The Double Cardan CV joint is functionally a constant velocity joint. How does its operating angle compare to other CV joints?</strong></p>
+        <p><strong>The Double Cardan CV joint is functionally a constant velocity joint. How does its operating angle compare to other CV joints?</strong></p>
         <label><input type="radio" name="q30" value="a"> It has a higher operating angle than Rzeppa joints.</label>
         <label><input type="radio" name="q30" value="b"> It has the widest operating angle of any CV joint type.</label>
         <label><input type="radio" name="q30" value="c"> Its operating angle is more limited than other types of CV joints.</label>
@@ -342,7 +342,7 @@
 
 
       <div class="question">
-        <p><strong>31. In a Double Cardan CV joint assembly, which component divides the drive angle evenly between the input and output shafts, helping to maintain constant velocity?</strong></p>
+        <p><strong>In a Double Cardan CV joint assembly, which component divides the drive angle evenly between the input and output shafts, helping to maintain constant velocity?</strong></p>
         <label><input type="radio" name="q31" value="a"> The companion flange</label>
         <label><input type="radio" name="q31" value="b"> The centering yoke</label>
         <label><input type="radio" name="q31" value="c"> The central ball and socket assembly</label>
@@ -351,7 +351,7 @@
 
 
       <div class="question">
-        <p><strong>32. The Rzeppa joint is a fixed depth CV joint. What feature allows it to maintain constant velocity with no speed change within the joint?</strong></p>
+        <p><strong>The Rzeppa joint is a fixed depth CV joint. What feature allows it to maintain constant velocity with no speed change within the joint?</strong></p>
         <label><input type="radio" name="q32" value="a"> Its use of long, straight ball grooves.</label>
         <label><input type="radio" name="q32" value="b"> Its three-trunnion spider design.</label>
         <label><input type="radio" name="q32" value="c"> The caged balls always operate in the centre of the drive angle.</label>
@@ -360,7 +360,7 @@
 
 
       <div class="question">
-        <p><strong>33. Where are Rzeppa joints most commonly used?</strong></p>
+        <p><strong>Where are Rzeppa joints most commonly used?</strong></p>
         <label><input type="radio" name="q33" value="a"> At the transmission output shaft (inboard position).</label>
         <label><input type="radio" name="q33" value="b"> On the propeller shaft of four-wheel drive trucks.</label>
         <label><input type="radio" name="q33" value="c"> On the outboard end of front halfshafts (at the wheel).</label>
@@ -369,7 +369,7 @@
 
 
       <div class="question">
-        <p><strong>34. Since the Rzeppa joint is a fixed joint and does not allow for driveshaft length change, it must always be used in conjunction with what other type of joint?</strong></p>
+        <p><strong>Since the Rzeppa joint is a fixed joint and does not allow for driveshaft length change, it must always be used in conjunction with what other type of joint?</strong></p>
         <label><input type="radio" name="q34" value="a"> A fixed yoke</label>
         <label><input type="radio" name="q34" value="b"> A Cardan U-joint</label>
         <label><input type="radio" name="q34" value="c"> A plunging joint or slip joint.</label>
@@ -378,7 +378,7 @@
 
 
       <div class="question">
-        <p><strong>35. The Double Offset Joint (modified Rzeppa) is classified as a plunge type CV joint. What design feature allows it to compensate for driveline length change?</strong></p>
+        <p><strong>The Double Offset Joint (modified Rzeppa) is classified as a plunge type CV joint. What design feature allows it to compensate for driveline length change?</strong></p>
         <label><input type="radio" name="q35" value="a"> The two cross-and-roller universal joints.</label>
         <label><input type="radio" name="q35" value="b"> The use of a tripod spider.</label>
         <label><input type="radio" name="q35" value="c"> Long, straight ball grooves in the input member (housing).</label>
@@ -387,7 +387,7 @@
 
 
       <div class="question">
-        <p><strong>36. Which type of plunging CV joint uses a three-trunnion spider with rollers running on needle bearings, and is typically used at the inboard position of FWD vehicles?</strong></p>
+        <p><strong>Which type of plunging CV joint uses a three-trunnion spider with rollers running on needle bearings, and is typically used at the inboard position of FWD vehicles?</strong></p>
         <label><input type="radio" name="q36" value="a"> Double Offset Joint</label>
         <label><input type="radio" name="q36" value="b"> Rzeppa Joint</label>
         <label><input type="radio" name="q36" value="c"> Tripod Joint (Tulip Joint)</label>
@@ -396,7 +396,7 @@
 
 
       <div class="question">
-        <p><strong>37. The Cross-Groove (Lobro) Joint is also a plunging joint. What unique design feature allows it to maintain the centred position of the balls and cage while compensating for substantial halfshaft length change?</strong></p>
+        <p><strong>The Cross-Groove (Lobro) Joint is also a plunging joint. What unique design feature allows it to maintain the centred position of the balls and cage while compensating for substantial halfshaft length change?</strong></p>
         <label><input type="radio" name="q37" value="a"> It uses a master spline on the inner race.</label>
         <label><input type="radio" name="q37" value="b"> It relies on a three-trunnion spider assembly.</label>
         <label><input type="radio" name="q37" value="c"> The ball grooves in the housing and inner race are machined at cross angles to each other.</label>
@@ -405,7 +405,7 @@
 
 
       <div class="question">
-        <p><strong>38. Why is it generally more economical to replace an entire rebuilt CV shaft assembly rather than rebuilding or replacing the individual joint?</strong></p>
+        <p><strong>Why is it generally more economical to replace an entire rebuilt CV shaft assembly rather than rebuilding or replacing the individual joint?</strong></p>
         <label><input type="radio" name="q38" value="a"> Joint components are rarely available separately.</label>
         <label><input type="radio" name="q38" value="b"> The price of replacement shaft assemblies makes it more economical.</label>
         <label><input type="radio" name="q38" value="c"> Rebuilt shafts eliminate the need for a core charge.</label>
@@ -414,7 +414,7 @@
 
 
       <div class="question">
-        <p><strong>39. The core charge on rebuilt shaft assemblies serves what explicit purpose?</strong></p>
+        <p><strong>The core charge on rebuilt shaft assemblies serves what explicit purpose?</strong></p>
         <label><input type="radio" name="q39" value="a"> To cover the cost of the rubber boots and clamps.</label>
         <label><input type="radio" name="q39" value="b"> To ensure the customer purchases a new axle retaining nut.</label>
         <label><input type="radio" name="q39" value="c"> To encourage customers to return the old shaft so it can be returned to the supplier for rebuilding.</label>
@@ -423,7 +423,7 @@
 
 
       <div class="question">
-        <p><strong>40. What type of lock nut is specifically designed to resist vibration loosening and must not be reused when installing front drive components?</strong></p>
+        <p><strong>What type of lock nut is specifically designed to resist vibration loosening and must not be reused when installing front drive components?</strong></p>
         <label><input type="radio" name="q40" value="a"> Castle nut with cotter pin</label>
         <label><input type="radio" name="q40" value="b"> Standard hex nut</label>
         <label><input type="radio" name="q40" value="c"> Torque-to-yield nut</label>
@@ -432,7 +432,7 @@
 
 
       <div class="question">
-        <p><strong>41. Why must a torque-to-yield axle retaining nut be replaced rather than reused?</strong></p>
+        <p><strong>Why must a torque-to-yield axle retaining nut be replaced rather than reused?</strong></p>
         <label><input type="radio" name="q41" value="a"> They are designed to operate at very sharp angles only.</label>
         <label><input type="radio" name="q41" value="b"> The nut is distorted during installation and a reused nut would not have the same resistance to vibration loosening as a new nut.</label>
         <label><input type="radio" name="q41" value="c"> They lose their ability to accommodate length changes.</label>
@@ -441,7 +441,7 @@
 
 
       <div class="question">
-        <p><strong>42. What is the essential replacement component that must be sold to the customer when they purchase a new universal joint kit to retain the joint in the yoke?</strong></p>
+        <p><strong>What is the essential replacement component that must be sold to the customer when they purchase a new universal joint kit to retain the joint in the yoke?</strong></p>
         <label><input type="radio" name="q42" value="a"> Inertia damper</label>
         <label><input type="radio" name="q42" value="b"> Slip yoke</label>
         <label><input type="radio" name="q42" value="c"> Fasteners and clamps (e.g., U-bolts, straps, snap rings)</label>
@@ -450,7 +450,7 @@
 
 
       <div class="question">
-        <p><strong>43. If a driveline component is classified as a &quot;driveshaft assembly&quot; failure, what related seals and sealing items are recommended replacement sales opportunities (Table 1)?</strong></p>
+        <p><strong>If a driveline component is classified as a &quot;driveshaft assembly&quot; failure, what related seals and sealing items are recommended replacement sales opportunities (Table 1)?</strong></p>
         <label><input type="radio" name="q43" value="a"> Only the universal joints.</label>
         <label><input type="radio" name="q43" value="b"> Only the axle retaining nut.</label>
         <label><input type="radio" name="q43" value="c"> Yokes, seals, nuts, transaxle housing axle seals, boot kits, boot bands, and boot clamps.</label>
@@ -459,7 +459,7 @@
 
 
       <div class="question">
-        <p><strong>44. Which of the following is listed as a function of the driveline?</strong></p>
+        <p><strong>Which of the following is listed as a function of the driveline?</strong></p>
         <label><input type="radio" name="q44" value="a"> To convert linear motion to rotational motion.</label>
         <label><input type="radio" name="q44" value="b"> To eliminate all driveline angle changes.</label>
         <label><input type="radio" name="q44" value="c"> To transfer power.</label>
@@ -468,7 +468,7 @@
 
 
       <div class="question">
-        <p><strong>45. What is the condition known as when a conventional U-joint causes the shaft it is driving to speed up and slow down as it transfers rotational motion through an angle?</strong></p>
+        <p><strong>What is the condition known as when a conventional U-joint causes the shaft it is driving to speed up and slow down as it transfers rotational motion through an angle?</strong></p>
         <label><input type="radio" name="q45" value="a"> Constant velocity</label>
         <label><input type="radio" name="q45" value="b"> Variable velocity</label>
         <label><input type="radio" name="q45" value="c"> Direct Drive</label>
@@ -477,7 +477,7 @@
 
 
       <div class="question">
-        <p><strong>46. When must shims be used between the centre support bearing assembly and the vehicle cross-member?</strong></p>
+        <p><strong>When must shims be used between the centre support bearing assembly and the vehicle cross-member?</strong></p>
         <label><input type="radio" name="q46" value="a"> To accommodate driveshaft length change.</label>
         <label><input type="radio" name="q46" value="b"> To adjust the backlash on the slip yoke splines.</label>
         <label><input type="radio" name="q46" value="c"> To adjust U-joint angles.</label>
@@ -486,7 +486,7 @@
 
 
       <div class="question">
-        <p><strong>47. Driveshafts that are constructed of inner and outer tubes joined by an elastomer (rubber) sleeve are designed to accomplish which specific task?</strong></p>
+        <p><strong>Driveshafts that are constructed of inner and outer tubes joined by an elastomer (rubber) sleeve are designed to accomplish which specific task?</strong></p>
         <label><input type="radio" name="q47" value="a"> To increase the driveshaft operating angle to 40 ° .</label>
         <label><input type="radio" name="q47" value="b"> To eliminate the transfer of driveline vibration up or down the shaft.</label>
         <label><input type="radio" name="q47" value="c"> To enable the shaft to operate as a plunge joint.</label>
@@ -495,7 +495,7 @@
 
 
       <div class="question">
-        <p><strong>48. What is the role of the bushing and rear seal in the transmission extension housing relative to the slip yoke?</strong></p>
+        <p><strong>What is the role of the bushing and rear seal in the transmission extension housing relative to the slip yoke?</strong></p>
         <label><input type="radio" name="q48" value="a"> The bushing locks the slip yoke into the splines.</label>
         <label><input type="radio" name="q48" value="b"> The outside surface of the steel tube of the slip yoke is machined smooth to seal with the transmission extension housing bushing and rear seal.</label>
         <label><input type="radio" name="q48" value="c"> The seal lubricates the internal splines of the yoke.</label>
@@ -504,7 +504,7 @@
 
 
       <div class="question">
-        <p><strong>49. What components are identified as the most common ones to be replaced on front-wheel drive vehicles?</strong></p>
+        <p><strong>What components are identified as the most common ones to be replaced on front-wheel drive vehicles?</strong></p>
         <label><input type="radio" name="q49" value="a"> Universal joints and slip yokes.</label>
         <label><input type="radio" name="q49" value="b"> Constant velocity joints and boot kits.</label>
         <label><input type="radio" name="q49" value="c"> Driveshaft tubing and fixed yokes.</label>
@@ -513,7 +513,7 @@
 
 
       <div class="question">
-        <p><strong>50. If a failed component is listed as a yoke and slip joint, what is a recommended related sales opportunity (Table 1)?</strong></p>
+        <p><strong>If a failed component is listed as a yoke and slip joint, what is a recommended related sales opportunity (Table 1)?</strong></p>
         <label><input type="radio" name="q50" value="a"> Only U-joints and axle retaining nuts.</label>
         <label><input type="radio" name="q50" value="b"> Boot kits and boot bands.</label>
         <label><input type="radio" name="q50" value="c"> Lubricant (grease), fasteners/clamp bolts, seals, U-joints, and axle retaining nuts.</label>

--- a/270202-test/270202g - Light-Duty Drive Axle Assemblies.html
+++ b/270202-test/270202g - Light-Duty Drive Axle Assemblies.html
@@ -70,7 +70,7 @@
 
 
             <div class="question">
-        <p><strong>1. What is the primary function of drive axle gear sets, regardless of whether they are used in a transaxle, RWD, AWD, or 4WD vehicle?</strong></p>
+        <p><strong>What is the primary function of drive axle gear sets, regardless of whether they are used in a transaxle, RWD, AWD, or 4WD vehicle?</strong></p>
         <label>
           <input type="radio" name="q1" value="a">
           A. To ensure both drive wheels turn at the same speed while cornering.
@@ -89,7 +89,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>2. In rear-wheel drive (RWD) and four-wheel drive (4WD) drive axle assemblies, which type of gear set is most commonly used for the ring gear and drive pinion?</strong></p>
+        <p><strong>In rear-wheel drive (RWD) and four-wheel drive (4WD) drive axle assemblies, which type of gear set is most commonly used for the ring gear and drive pinion?</strong></p>
         <label>
           <input type="radio" name="q2" value="a">
           A. Helical gears
@@ -108,7 +108,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>3. The design of a hypoid gear set allows the driveshaft to be lowered, thereby lowering the overall vehicle profile. This is achieved because the drive pinion shaft centerline is located:</strong></p>
+        <p><strong>The design of a hypoid gear set allows the driveshaft to be lowered, thereby lowering the overall vehicle profile. This is achieved because the drive pinion shaft centerline is located:</strong></p>
         <label>
           <input type="radio" name="q3" value="a">
           A. In the same plane as the ring gear centerline.
@@ -127,7 +127,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>4. What is the consequence of the large curvature of the gear teeth in a hypoid gear set?</strong></p>
+        <p><strong>What is the consequence of the large curvature of the gear teeth in a hypoid gear set?</strong></p>
         <label>
           <input type="radio" name="q4" value="a">
           A. It eliminates the need for lubrication.
@@ -146,7 +146,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>5. Which gear type, shaped like truncated cones for strength, is characterized by producing thrust as the gears want to separate when torque is applied, making them suitable for use in the differential assembly?</strong></p>
+        <p><strong>Which gear type, shaped like truncated cones for strength, is characterized by producing thrust as the gears want to separate when torque is applied, making them suitable for use in the differential assembly?</strong></p>
         <label>
           <input type="radio" name="q5" value="a">
           A. Helical gears
@@ -165,7 +165,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>6. What gear type is typically used in the differential unit as the differential pinion gears and axle or side gears?</strong></p>
+        <p><strong>What gear type is typically used in the differential unit as the differential pinion gears and axle or side gears?</strong></p>
         <label>
           <input type="radio" name="q6" value="a">
           A. Hypoid gears
@@ -184,7 +184,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>7. The primary reason bevelled spur gears (used in the differential) are considered a relatively weak gear set is that:</strong></p>
+        <p><strong>The primary reason bevelled spur gears (used in the differential) are considered a relatively weak gear set is that:</strong></p>
         <label>
           <input type="radio" name="q7" value="a">
           A. They produce excessive side thrust.
@@ -203,7 +203,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>8. In a transverse-mounted transaxle assembly, which uses helical drive axle gears, what is the required change in the path of power?</strong></p>
+        <p><strong>In a transverse-mounted transaxle assembly, which uses helical drive axle gears, what is the required change in the path of power?</strong></p>
         <label>
           <input type="radio" name="q8" value="a">
           A. The path of power must turn 90 ° from the input.
@@ -222,7 +222,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>9. Drive axle gear sets transfer power between two shafts whose centrelines are parallel. What is the most common type of gear used for this application, particularly in front-wheel drive vehicles?</strong></p>
+        <p><strong>Drive axle gear sets transfer power between two shafts whose centrelines are parallel. What is the most common type of gear used for this application, particularly in front-wheel drive vehicles?</strong></p>
         <label>
           <input type="radio" name="q9" value="a">
           A. Hypoid gears
@@ -241,7 +241,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>10. What is the mathematical method used to calculate the gear ratio of the crown and pinion set?</strong></p>
+        <p><strong>What is the mathematical method used to calculate the gear ratio of the crown and pinion set?</strong></p>
         <label>
           <input type="radio" name="q10" value="a">
           A. Dividing the number of teeth on the pinion by the number of teeth on the ring gear.
@@ -260,7 +260,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>11. Which axle type is most common in rear-wheel drive passenger vehicles and supports the weight of the vehicle while propelling the wheel?</strong></p>
+        <p><strong>Which axle type is most common in rear-wheel drive passenger vehicles and supports the weight of the vehicle while propelling the wheel?</strong></p>
         <label>
           <input type="radio" name="q11" value="a">
           A. Full floating axle
@@ -279,7 +279,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>12. A full floating axle is commonly found on 3/4-ton and heavier vehicles. Which function is solely performed by the axle shaft in this design?</strong></p>
+        <p><strong>A full floating axle is commonly found on 3/4-ton and heavier vehicles. Which function is solely performed by the axle shaft in this design?</strong></p>
         <label>
           <input type="radio" name="q12" value="a">
           A. Supporting the vehicle weight.
@@ -298,7 +298,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>13. In a semi-floating axle that uses straight roller bearings to support the axle shaft, how is the required side thrust control transferred to the axle housing?</strong></p>
+        <p><strong>In a semi-floating axle that uses straight roller bearings to support the axle shaft, how is the required side thrust control transferred to the axle housing?</strong></p>
         <label>
           <input type="radio" name="q13" value="a">
           A. The outer bearing retainer plate absorbs the thrust directly.
@@ -317,7 +317,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>14. To service an axle in an integral carrier axle housing, which procedure must be performed first?</strong></p>
+        <p><strong>To service an axle in an integral carrier axle housing, which procedure must be performed first?</strong></p>
         <label>
           <input type="radio" name="q14" value="a">
           A. Remove the companion flange.
@@ -336,7 +336,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>15. What distinguishes the integral carrier axle housing from the removable carrier (banjo type) axle housing?</strong></p>
+        <p><strong>What distinguishes the integral carrier axle housing from the removable carrier (banjo type) axle housing?</strong></p>
         <label>
           <input type="radio" name="q15" value="a">
           A. The integral carrier uses steel axle tubes, while the removable carrier uses cast iron tubes.
@@ -355,7 +355,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>16. What critical adjustment is controlled by the side-to-side position of the differential case, which is set using selective shims or threaded adjusters?</strong></p>
+        <p><strong>What critical adjustment is controlled by the side-to-side position of the differential case, which is set using selective shims or threaded adjusters?</strong></p>
         <label>
           <input type="radio" name="q16" value="a">
           A. Pinion depth
@@ -374,7 +374,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>17. To maintain proper preload on drive pinion tapered roller bearings, many manufacturers utilize a crush sleeve positioned between the bearings. What is the mandatory replacement rule concerning this component?</strong></p>
+        <p><strong>To maintain proper preload on drive pinion tapered roller bearings, many manufacturers utilize a crush sleeve positioned between the bearings. What is the mandatory replacement rule concerning this component?</strong></p>
         <label>
           <input type="radio" name="q17" value="a">
           A. It must be lubricated with high-viscosity gear oil upon removal.
@@ -393,7 +393,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>18. What is the fundamental requirement for bevel gears used in the differential, such as bevelled spur gears, regarding the shafts they connect?</strong></p>
+        <p><strong>What is the fundamental requirement for bevel gears used in the differential, such as bevelled spur gears, regarding the shafts they connect?</strong></p>
         <label>
           <input type="radio" name="q18" value="a">
           A. They must provide a very large torque multiplication.
@@ -412,7 +412,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>19. In a standard differential, when a vehicle is driving in a straight line, what is the state of the gear rotation?</strong></p>
+        <p><strong>In a standard differential, when a vehicle is driving in a straight line, what is the state of the gear rotation?</strong></p>
         <label>
           <input type="radio" name="q19" value="a">
           A. The pinion gears rotate on their shaft to divide torque.
@@ -431,7 +431,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>20. When a vehicle with a standard differential is rounding a corner, what occurs regarding the speed of the wheels relative to the differential case?</strong></p>
+        <p><strong>When a vehicle with a standard differential is rounding a corner, what occurs regarding the speed of the wheels relative to the differential case?</strong></p>
         <label>
           <input type="radio" name="q20" value="a">
           A. The inside wheel speeds up, and the outside wheel slows down.
@@ -450,7 +450,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>21. What component of the standard differential ensures that torque is divided equally between both drive wheels?</strong></p>
+        <p><strong>What component of the standard differential ensures that torque is divided equally between both drive wheels?</strong></p>
         <label>
           <input type="radio" name="q21" value="a">
           A. The ring gear
@@ -469,7 +469,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>22. A standard differential always splits the torque equally between the two driving wheels. If one wheel is on a slippery surface (ice), what is the maximum torque that can be delivered to the wheel with traction?</strong></p>
+        <p><strong>A standard differential always splits the torque equally between the two driving wheels. If one wheel is on a slippery surface (ice), what is the maximum torque that can be delivered to the wheel with traction?</strong></p>
         <label>
           <input type="radio" name="q22" value="a">
           A. The torque required to overcome friction at the wheel with traction.
@@ -488,7 +488,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>23. Traction-enhancing differentials are classified into two main categories: those that limit differential action and those that eliminate differential action completely. Which category is achieved by mechanically locking the two axles together?</strong></p>
+        <p><strong>Traction-enhancing differentials are classified into two main categories: those that limit differential action and those that eliminate differential action completely. Which category is achieved by mechanically locking the two axles together?</strong></p>
         <label>
           <input type="radio" name="q23" value="a">
           A. Friction designs
@@ -507,7 +507,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>24. A differential with four differential pinion gears instead of the standard two is used to provide what specific performance characteristic?</strong></p>
+        <p><strong>A differential with four differential pinion gears instead of the standard two is used to provide what specific performance characteristic?</strong></p>
         <label>
           <input type="radio" name="q24" value="a">
           A. Better traction on slippery surfaces.
@@ -526,7 +526,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>25. Disc Clutch Differentials (Limited Slip, Posi-Trac, etc.) use friction plates (clutch packs) that are stacked alternately between internally splined plates (engaging the side gear) and externally splined plates (engaging the differential case). When loss of traction occurs, what happens?</strong></p>
+        <p><strong>Disc Clutch Differentials (Limited Slip, Posi-Trac, etc.) use friction plates (clutch packs) that are stacked alternately between internally splined plates (engaging the side gear) and externally splined plates (engaging the differential case). When loss of traction occurs, what happens?</strong></p>
         <label>
           <input type="radio" name="q25" value="a">
           A. The clutch pack disengages, allowing the wheel with traction to spin.
@@ -545,7 +545,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>26. In a disc clutch differential, what components supply the spring tension necessary to compress the clutch packs, thereby creating the clutch preload?</strong></p>
+        <p><strong>In a disc clutch differential, what components supply the spring tension necessary to compress the clutch packs, thereby creating the clutch preload?</strong></p>
         <label>
           <input type="radio" name="q26" value="a">
           A. Axial loads generated by the wheel bearings.
@@ -564,7 +564,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>27. Traction-enhancing differentials utilize the natural tendency of bevelled spur gears to thrust one another apart under load. This thrust is transferred to the axle side gear and used to provide what function?</strong></p>
+        <p><strong>Traction-enhancing differentials utilize the natural tendency of bevelled spur gears to thrust one another apart under load. This thrust is transferred to the axle side gear and used to provide what function?</strong></p>
         <label>
           <input type="radio" name="q27" value="a">
           A. Additional compression on the clutch packs behind the axle gears.
@@ -583,7 +583,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>28. The multi-disc limited slip differential does not permanently lock the differential case and axle side gears. What condition allows normal differential action (slippage) to occur when turning a corner?</strong></p>
+        <p><strong>The multi-disc limited slip differential does not permanently lock the differential case and axle side gears. What condition allows normal differential action (slippage) to occur when turning a corner?</strong></p>
         <label>
           <input type="radio" name="q28" value="a">
           A. The pinion gears stop rotating on their shaft.
@@ -602,7 +602,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>29. If a vehicle is equipped with a limited slip differential (LSD) assembly, what maintenance additive is generally required and may be contained in a special lubricant or supplied separately?</strong></p>
+        <p><strong>If a vehicle is equipped with a limited slip differential (LSD) assembly, what maintenance additive is generally required and may be contained in a special lubricant or supplied separately?</strong></p>
         <label>
           <input type="radio" name="q29" value="a">
           A. Extreme-pressure (EP) additive.
@@ -621,7 +621,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>30. Cone Clutch Differentials operate on the same principle as disc clutch types, but instead use cone clutches placed between the side gears and the differential case. What feature on the cone’s machined surface is designed to cut through the lubrication film and bite into the differential case?</strong></p>
+        <p><strong>Cone Clutch Differentials operate on the same principle as disc clutch types, but instead use cone clutches placed between the side gears and the differential case. What feature on the cone’s machined surface is designed to cut through the lubrication film and bite into the differential case?</strong></p>
         <label>
           <input type="radio" name="q30" value="a">
           A. Axial splines
@@ -640,7 +640,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>31. In a Viscous Coupling Differential (popular in AWD and SUV applications), torque transfer occurs due to the use of viscous silicone oil and multiple perforated plates. What property of the silicone oil causes it to become more adhesive and resistant to flow?</strong></p>
+        <p><strong>In a Viscous Coupling Differential (popular in AWD and SUV applications), torque transfer occurs due to the use of viscous silicone oil and multiple perforated plates. What property of the silicone oil causes it to become more adhesive and resistant to flow?</strong></p>
         <label>
           <input type="radio" name="q31" value="a">
           A. High oxidation resistance.
@@ -659,7 +659,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>32. The Eaton Locking Clutch Differential is distinct because there is almost no discernible drag until the locking feature is activated by what mechanism?</strong></p>
+        <p><strong>The Eaton Locking Clutch Differential is distinct because there is almost no discernible drag until the locking feature is activated by what mechanism?</strong></p>
         <label>
           <input type="radio" name="q32" value="a">
           A. The friction discs slipping excessively.
@@ -678,7 +678,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>33. How does a technician typically confirm that a differential is a traction-enhancing type (rather than a standard differential) without dismantling it?</strong></p>
+        <p><strong>How does a technician typically confirm that a differential is a traction-enhancing type (rather than a standard differential) without dismantling it?</strong></p>
         <label>
           <input type="radio" name="q33" value="a">
           A. Drive the vehicle slowly around a corner and listen for gear clash.
@@ -697,7 +697,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>34. Locking differentials eliminate differential action completely by mechanically locking the two axles together. When is this locking action typically initiated in an Eaton Locker type differential?</strong></p>
+        <p><strong>Locking differentials eliminate differential action completely by mechanically locking the two axles together. When is this locking action typically initiated in an Eaton Locker type differential?</strong></p>
         <label>
           <input type="radio" name="q34" value="a">
           A. Immediately when the clutch is disengaged.
@@ -716,7 +716,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>35. The term preload (in the context of tapered roller bearings) is defined as the pressure required to make the bearing and the race contact each other, causing the rollers to rotate. What is the explicit purpose of this preload?</strong></p>
+        <p><strong>The term preload (in the context of tapered roller bearings) is defined as the pressure required to make the bearing and the race contact each other, causing the rollers to rotate. What is the explicit purpose of this preload?</strong></p>
         <label>
           <input type="radio" name="q35" value="a">
           A. To lubricate the bearing surfaces.
@@ -735,7 +735,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>36. What is the classification of gear oil that is recommended for use with hypoid gear sets?</strong></p>
+        <p><strong>What is the classification of gear oil that is recommended for use with hypoid gear sets?</strong></p>
         <label>
           <input type="radio" name="q36" value="a">
           A. SAE 75W
@@ -754,7 +754,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>37. What is the specific role of an extreme-pressure (EP) additive like zinc dithiophosphate in drive axle gear oil?</strong></p>
+        <p><strong>What is the specific role of an extreme-pressure (EP) additive like zinc dithiophosphate in drive axle gear oil?</strong></p>
         <label>
           <input type="radio" name="q37" value="a">
           A. To minimize foaming during high-speed rotation.
@@ -773,7 +773,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>38. Which of the following is a potential consequence if the drive axle breather vent is not kept unrestricted?</strong></p>
+        <p><strong>Which of the following is a potential consequence if the drive axle breather vent is not kept unrestricted?</strong></p>
         <label>
           <input type="radio" name="q38" value="a">
           A. Gear oil viscosity will break down rapidly.
@@ -792,7 +792,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>39. Drive axle gear oil must be checked against the manufacturer&#x27;s specifications for two major classifications: SAE (viscosity) and API (application). Why must a customer always check manufacturer specifications before adding any fluid?</strong></p>
+        <p><strong>Drive axle gear oil must be checked against the manufacturer&#x27;s specifications for two major classifications: SAE (viscosity) and API (application). Why must a customer always check manufacturer specifications before adding any fluid?</strong></p>
         <label>
           <input type="radio" name="q39" value="a">
           A. To ensure the fluid can resist mechanical linkage wear.
@@ -811,7 +811,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>40. How does the splash lubrication system commonly used in remote axle assemblies ensure internal components are lubricated?</strong></p>
+        <p><strong>How does the splash lubrication system commonly used in remote axle assemblies ensure internal components are lubricated?</strong></p>
         <label>
           <input type="radio" name="q40" value="a">
           A. The transaxle dipstick checks the oil level in the common sump.
@@ -830,7 +830,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>41. In a transversely mounted transaxle using helical drive axle gears, how do the demands on the lubricating oil compare to those of a rear axle assembly using hypoid gear sets?</strong></p>
+        <p><strong>In a transversely mounted transaxle using helical drive axle gears, how do the demands on the lubricating oil compare to those of a rear axle assembly using hypoid gear sets?</strong></p>
         <label>
           <input type="radio" name="q41" value="a">
           A. The demands on the oil are equally high due to axial thrust.
@@ -849,7 +849,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>42. What is the primary method for identifying the specific drive axle assembly when providing replacement crown and pinions?</strong></p>
+        <p><strong>What is the primary method for identifying the specific drive axle assembly when providing replacement crown and pinions?</strong></p>
         <label>
           <input type="radio" name="q42" value="a">
           A. Matching the ratio (e.g., 3.50) stamped on the axle tube.
@@ -868,7 +868,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>43. Axle shafts are manufactured with splines machined at the inner end. What is the purpose of these splines?</strong></p>
+        <p><strong>Axle shafts are manufactured with splines machined at the inner end. What is the purpose of these splines?</strong></p>
         <label>
           <input type="radio" name="q43" value="a">
           A. To accommodate C-locks for side thrust control.
@@ -887,7 +887,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>44. Axial loads are defined as loads that run parallel to the centerline of the shaft. Which type of bearing is normally used in most drive axle applications because it can accept and control both radial and axial loads?</strong></p>
+        <p><strong>Axial loads are defined as loads that run parallel to the centerline of the shaft. Which type of bearing is normally used in most drive axle applications because it can accept and control both radial and axial loads?</strong></p>
         <label>
           <input type="radio" name="q44" value="a">
           A. Straight roller bearings
@@ -906,7 +906,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>45. When a differential is subjected to the spinning of one wheel (such as when stuck), severe wear can occur to the differential pinion gears. This is because:</strong></p>
+        <p><strong>When a differential is subjected to the spinning of one wheel (such as when stuck), severe wear can occur to the differential pinion gears. This is because:</strong></p>
         <label>
           <input type="radio" name="q45" value="a">
           A. They are made of bevelled spur gears, a relatively weak set.
@@ -925,7 +925,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>46. When a pinion seal (#41) fails, which common related sales items should a parts technician suggest to the customer (Table 2)?</strong></p>
+        <p><strong>When a pinion seal (#41) fails, which common related sales items should a parts technician suggest to the customer (Table 2)?</strong></p>
         <label>
           <input type="radio" name="q46" value="a">
           A. Companion flange/yoke, crush sleeve, and gear lube.
@@ -944,7 +944,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>47. When a differential case fails, what essential components are suggested as related sales, according to Table 2?</strong></p>
+        <p><strong>When a differential case fails, what essential components are suggested as related sales, according to Table 2?</strong></p>
         <label>
           <input type="radio" name="q47" value="a">
           A. Bearings, gasket and seals, differential cross-shaft, differential gears, shims, crush sleeve, gasket, and gear lube.
@@ -963,7 +963,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>48. When a semi-floating axle uses a ball bearing type for support, how are the side thrust forces transferred from the axle to the axle housing?</strong></p>
+        <p><strong>When a semi-floating axle uses a ball bearing type for support, how are the side thrust forces transferred from the axle to the axle housing?</strong></p>
         <label>
           <input type="radio" name="q48" value="a">
           A. Via the C-lock and differential pinion shaft.
@@ -982,7 +982,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>49. What is the purpose of the flats usually milled onto the bearing surface of the differential pinion shaft?</strong></p>
+        <p><strong>What is the purpose of the flats usually milled onto the bearing surface of the differential pinion shaft?</strong></p>
         <label>
           <input type="radio" name="q49" value="a">
           A. To allow the shaft to be secured by a threaded pin.
@@ -1001,7 +1001,7 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>50. Based on the identification tag example (Figure 11), a ratio stamped as 3L00 indicates what specific design feature of the axle assembly?</strong></p>
+        <p><strong>Based on the identification tag example (Figure 11), a ratio stamped as 3L00 indicates what specific design feature of the axle assembly?</strong></p>
         <label>
           <input type="radio" name="q50" value="a">
           A. A removable carrier housing

--- a/270202-test/270202h - Heavy-Duty Drive Axle Assemblies.html
+++ b/270202-test/270202h - Heavy-Duty Drive Axle Assemblies.html
@@ -70,7 +70,7 @@
 
 
  <div class="question">
-            <p><strong>1. A tandem drive axle model is designated as DS404-P. Using the identification codes, what is the nominal Gross Axle Weight Rating (GAWR) per tandem in pounds?</strong></p>
+            <p><strong>A tandem drive axle model is designated as DS404-P. Using the identification codes, what is the nominal Gross Axle Weight Rating (GAWR) per tandem in pounds?</strong></p>
             <label><input type="radio" name="q1" value="a"> A. 4,000 pounds</label>
             <label><input type="radio" name="q1" value="b"> B. 10,000 pounds</label>
             <label><input type="radio" name="q1" value="c"> C. 40,000 pounds</label>
@@ -78,7 +78,7 @@
         </div>
 
         <div class="question">
-            <p><strong>2. A carrier assembly has two gear reductions. The first reduction ratio (input pinion to bevel gear) is 2.5:1, and the second reduction ratio (helical pinion to helical driven gear) is 2.0:1. What is the overall gear ratio through this carrier assembly?</strong></p>
+            <p><strong>A carrier assembly has two gear reductions. The first reduction ratio (input pinion to bevel gear) is 2.5:1, and the second reduction ratio (helical pinion to helical driven gear) is 2.0:1. What is the overall gear ratio through this carrier assembly?</strong></p>
             <label><input type="radio" name="q2" value="a"> A. 0.5:1</label>
             <label><input type="radio" name="q2" value="b"> B. 2.5:1</label>
             <label><input type="radio" name="q2" value="c"> C. 5.0:1</label>
@@ -86,7 +86,7 @@
         </div>
 
         <div class="question">
-            <p><strong>3. In a standard differential under good traction conditions, the total torque received by the differential case assembly is 4067.4 Nm (3000 lb-ft). If the torque is divided equally, how much torque is sent to each axle shaft?</strong></p>
+            <p><strong>In a standard differential under good traction conditions, the total torque received by the differential case assembly is 4067.4 Nm (3000 lb-ft). If the torque is divided equally, how much torque is sent to each axle shaft?</strong></p>
             <label><input type="radio" name="q3" value="a"> A. 1016.85 Nm (750 lb-ft)</label>
             <label><input type="radio" name="q3" value="b"> B. 1355.8 Nm (1000 lb-ft)</label>
             <label><input type="radio" name="q3" value="c"> C. 2033.7 Nm (1500 lb-ft)</label>
@@ -94,7 +94,7 @@
         </div>
 
         <div class="question">
-            <p><strong>4. A planetary two-speed drive axle assembly has a crown gear set ratio of 3.5:1 and a planetary gear set ratio of 1.5:1 (Double Reduction in Low). What is the overall gear ratio when the assembly is operating in Low Speed?</strong></p>
+            <p><strong>A planetary two-speed drive axle assembly has a crown gear set ratio of 3.5:1 and a planetary gear set ratio of 1.5:1 (Double Reduction in Low). What is the overall gear ratio when the assembly is operating in Low Speed?</strong></p>
             <label><input type="radio" name="q4" value="a"> A. 2.33:1</label>
             <label><input type="radio" name="q4" value="b"> B. 3.5:1</label>
             <label><input type="radio" name="q4" value="c"> C. 5.0:1</label>
@@ -102,7 +102,7 @@
         </div>
 
         <div class="question">
-            <p><strong>5. A drive axle assembly has a crown gear with 48 teeth and a drive pinion with 10 teeth. What is the final drive gear ratio?</strong></p>
+            <p><strong>A drive axle assembly has a crown gear with 48 teeth and a drive pinion with 10 teeth. What is the final drive gear ratio?</strong></p>
             <label><input type="radio" name="q5" value="a"> A. 0.20:1</label>
             <label><input type="radio" name="q5" value="b"> B. 4.00:1</label>
             <label><input type="radio" name="q5" value="c"> C. 4.80:1</label>
@@ -110,7 +110,7 @@
         </div>
 
         <div class="question">
-            <p><strong>6. A drive axle assembly has a crown gear with 39 teeth and a drive pinion with 11 teeth. What is the final drive gear ratio? Round to two decimal places.</strong></p>
+            <p><strong>A drive axle assembly has a crown gear with 39 teeth and a drive pinion with 11 teeth. What is the final drive gear ratio? Round to two decimal places.</strong></p>
             <label><input type="radio" name="q6" value="a"> A. 3.55:1</label>
             <label><input type="radio" name="q6" value="b"> B. 3.73:1</label>
             <label><input type="radio" name="q6" value="c"> C. 3.91:1</label>
@@ -118,7 +118,7 @@
         </div>
 
         <div class="question">
-            <p><strong>7. In a differential wheel spin condition, the crown gear is turning at 100 rpm and the axle shaft on one side is stopped (0 rpm). According to the differential action principle, what speed must the opposite axle wheel turn?</strong></p>
+            <p><strong>In a differential wheel spin condition, the crown gear is turning at 100 rpm and the axle shaft on one side is stopped (0 rpm). According to the differential action principle, what speed must the opposite axle wheel turn?</strong></p>
             <label><input type="radio" name="q7" value="a"> A. 50 rpm</label>
             <label><input type="radio" name="q7" value="b"> B. 100 rpm</label>
             <label><input type="radio" name="q7" value="c"> C. 200 rpm</label>
@@ -126,7 +126,7 @@
         </div>
 
         <div class="question">
-            <p><strong>8. In an inter-axle differential spin-out condition, the forward drive axle pinion is stationary. If the inter-axle differential cross shaft is rotating at 500 rpm, what speed would the rearward drive axle pinion be spinning due to differential action?</strong></p>
+            <p><strong>In an inter-axle differential spin-out condition, the forward drive axle pinion is stationary. If the inter-axle differential cross shaft is rotating at 500 rpm, what speed would the rearward drive axle pinion be spinning due to differential action?</strong></p>
             <label><input type="radio" name="q8" value="a"> A. 500 rpm</label>
             <label><input type="radio" name="q8" value="b"> B. 750 rpm</label>
             <label><input type="radio" name="q8" value="c"> C. 1000 rpm</label>
@@ -134,7 +134,7 @@
         </div>
 
         <div class="question">
-            <p><strong>9. Which gear arrangement term describes a drive pinion that meshes with its crown (bevel) gear above the centerline of the crown gear?</strong></p>
+            <p><strong>Which gear arrangement term describes a drive pinion that meshes with its crown (bevel) gear above the centerline of the crown gear?</strong></p>
             <label><input type="radio" name="q9" value="a"> A. Hypoid</label>
             <label><input type="radio" name="q9" value="b"> B. Straddle mount</label>
             <label><input type="radio" name="q9" value="c"> C. Amboid</label>
@@ -142,7 +142,7 @@
         </div>
 
         <div class="question">
-            <p><strong>10. A straddle mount pinion design, which is characterized by a pilot bearing surface extending past the end of the pinion gear, is more common on applications that experience:</strong></p>
+            <p><strong>A straddle mount pinion design, which is characterized by a pilot bearing surface extending past the end of the pinion gear, is more common on applications that experience:</strong></p>
             <label><input type="radio" name="q10" value="a"> A. Low revolutions per minute (rpm) rates.</label>
             <label><input type="radio" name="q10" value="b"> B. High torque loads.</label>
             <label><input type="radio" name="q10" value="c"> C. Single-speed single reduction.</label>
@@ -150,7 +150,7 @@
         </div>
 
         <div class="question">
-            <p><strong>11. What is the fundamental requirement when replacing a drive pinion and crown gear set?</strong></p>
+            <p><strong>What is the fundamental requirement when replacing a drive pinion and crown gear set?</strong></p>
             <label><input type="radio" name="q11" value="a"> A. They must be individually balanced and installed with new thrust washers.</label>
             <label><input type="radio" name="q11" value="b"> B. The pinion depth must be adjusted using the pinion bearing preload spacer.</label>
             <label><input type="radio" name="q11" value="c"> C. They must be used in matched sets as they are designed together.</label>
@@ -158,7 +158,7 @@
         </div>
 
         <div class="question">
-            <p><strong>12. The Gross Axle Weight Rating (GAWR) is the manufacturer's rating that dictates the construction of the housing, bearings, and wheel ends based on the weight the axle must:</strong></p>
+            <p><strong>The Gross Axle Weight Rating (GAWR) is the manufacturer's rating that dictates the construction of the housing, bearings, and wheel ends based on the weight the axle must:</strong></p>
             <label><input type="radio" name="q12" value="a"> A. Propel (Torque transfer).</label>
             <label><input type="radio" name="q12" value="b"> B. Safely carry (Load support).</label>
             <label><input type="radio" name="q12" value="c"> C. Transfer during a full-floating configuration.</label>
@@ -166,7 +166,7 @@
         </div>
 
         <div class="question">
-            <p><strong>13. When all of the individual Gross Axle Weight Ratings (GAWR) for a vehicle are added together, they establish the total weight of the vehicle and its load, which is known as the:</strong></p>
+            <p><strong>When all of the individual Gross Axle Weight Ratings (GAWR) for a vehicle are added together, they establish the total weight of the vehicle and its load, which is known as the:</strong></p>
             <label><input type="radio" name="q13" value="a"> A. Tare Weight.</label>
             <label><input type="radio" name="q13" value="b"> B. Gross Combination Weight Rating (GCWR).</label>
             <label><input type="radio" name="q13" value="c"> C. Gross Vehicle Weight Rating (GVWR).</label>
@@ -174,7 +174,7 @@
         </div>
 
         <div class="question">
-            <p><strong>14. What is the primary functional difference between a live axle and a dead axle?</strong></p>
+            <p><strong>What is the primary functional difference between a live axle and a dead axle?</strong></p>
             <label><input type="radio" name="q14" value="a"> A. A live axle is found on tandem arrangements; a dead axle is found on tridem arrangements.</label>
             <label><input type="radio" name="q14" value="b"> B. A live axle propels the vehicle; a dead axle strictly carries the load.</label>
             <label><input type="radio" name="q14" value="c"> C. A live axle always uses a planetary two-speed carrier; a dead axle uses a single-speed reduction.</label>
@@ -182,7 +182,7 @@
         </div>
 
         <div class="question">
-            <p><strong>15. What is the critical action that must occur to remove a semi-floating axle shaft from a vehicle, compared to a full-floating axle shaft?</strong></p>
+            <p><strong>What is the critical action that must occur to remove a semi-floating axle shaft from a vehicle, compared to a full-floating axle shaft?</strong></p>
             <label><input type="radio" name="q15" value="a"> A. The axle must be locked by the differential lock.</label>
             <label><input type="radio" name="q15" value="b"> B. The rear cover must be removed first.</label>
             <label><input type="radio" name="q15" value="c"> C. A drive wheel must be raised off the ground before a semi-floating axle shaft can be removed.</label>
@@ -190,7 +190,7 @@
         </div>
 
         <div class="question">
-            <p><strong>16. What is the main function of the full-floating axle shaft?</strong></p>
+            <p><strong>What is the main function of the full-floating axle shaft?</strong></p>
             <label><input type="radio" name="q16" value="a"> A. To carry the weight of the vehicle and cargo.</label>
             <label><input type="radio" name="q16" value="b"> B. To transmit braking and cornering forces.</label>
             <label><input type="radio" name="q16" value="c"> C. To drive the wheel and hub assembly.</label>
@@ -198,7 +198,7 @@
         </div>
 
         <div class="question">
-            <p><strong>17. If a heavy-duty truck has a tandem or tridem drive axle arrangement, what component must be added to transmit power from one drive axle to the next?</strong></p>
+            <p><strong>If a heavy-duty truck has a tandem or tridem drive axle arrangement, what component must be added to transmit power from one drive axle to the next?</strong></p>
             <label><input type="radio" name="q17" value="a"> A. A planetary two-speed axle assembly.</label>
             <label><input type="radio" name="q17" value="b"> B. A speed sensing unit.</label>
             <label><input type="radio" name="q17" value="c"> C. An inter-axle differential assembly.</label>
@@ -206,7 +206,7 @@
         </div>
 
         <div class="question">
-            <p><strong>18. What is the primary characteristic of a single-speed single reduction carrier assembly?</strong></p>
+            <p><strong>What is the primary characteristic of a single-speed single reduction carrier assembly?</strong></p>
             <label><input type="radio" name="q18" value="a"> A. It provides two separate gear reductions.</label>
             <label><input type="radio" name="q18" value="b"> B. It uses helical gears for the final reduction.</label>
             <label><input type="radio" name="q18" value="c"> C. It offers only one path-of-power and one gear reduction through the drive pinion and crown gear.</label>
@@ -214,7 +214,7 @@
         </div>
 
         <div class="question">
-            <p><strong>19. In a single-speed double reduction carrier assembly, the second gear reduction is accomplished through a set of:</strong></p>
+            <p><strong>In a single-speed double reduction carrier assembly, the second gear reduction is accomplished through a set of:</strong></p>
             <label><input type="radio" name="q19" value="a"> A. Hypoid gears.</label>
             <label><input type="radio" name="q19" value="b"> B. Straight spur gears.</label>
             <label><input type="radio" name="q19" value="c"> C. Helical gears.</label>
@@ -222,7 +222,7 @@
         </div>
 
         <div class="question">
-            <p><strong>20. What is the common name given to the component that houses the bearings supporting the drive pinion, and may be a removable piece of the carrier housing?</strong></p>
+            <p><strong>What is the common name given to the component that houses the bearings supporting the drive pinion, and may be a removable piece of the carrier housing?</strong></p>
             <label><input type="radio" name="q20" value="a"> A. Differential Housing</label>
             <label><input type="radio" name="q20" value="b"> B. Pinion Bearing Cage</label>
             <label><input type="radio" name="q20" value="c"> C. Differential Case Half</label>
@@ -230,7 +230,7 @@
         </div>
 
         <div class="question">
-            <p><strong>21. What component is used as a selective spacer to determine the pinion bearing preload in the pinion cage assembly?</strong></p>
+            <p><strong>What component is used as a selective spacer to determine the pinion bearing preload in the pinion cage assembly?</strong></p>
             <label><input type="radio" name="q21" value="a"> A. Pinion position shims</label>
             <label><input type="radio" name="q21" value="b"> B. Drive pinion nut</label>
             <label><input type="radio" name="q21" value="c"> C. Pinion preload spacer</label>
@@ -238,7 +238,7 @@
         </div>
 
         <div class="question">
-            <p><strong>22. What design feature characterizes an overhung mount input drive pinion when viewed from the side?</strong></p>
+            <p><strong>What design feature characterizes an overhung mount input drive pinion when viewed from the side?</strong></p>
             <label><input type="radio" name="q22" value="a"> A. A pilot bearing surface that extends past the end of the gear.</label>
             <label><input type="radio" name="q22" value="b"> B. A flat surface at the end of the pinion gear (flat pinion face).</label>
             <label><input type="radio" name="q22" value="c"> C. It meshes with the crown gear below the centerline.</label>
@@ -246,7 +246,7 @@
         </div>
 
         <div class="question">
-            <p><strong>23. Why is a special thrust screw and jam nut sometimes used on drive axle assemblies?</strong></p>
+            <p><strong>Why is a special thrust screw and jam nut sometimes used on drive axle assemblies?</strong></p>
             <label><input type="radio" name="q23" value="a"> A. To adjust the backlash between the differential side gears.</label>
             <label><input type="radio" name="q23" value="b"> B. To help prevent the crown gear from deflecting away from the pinion during high torque load.</label>
             <label><input type="radio" name="q23" value="c"> C. To provide a mounting surface for the differential bearing adjuster.</label>
@@ -254,7 +254,7 @@
         </div>
 
         <div class="question">
-            <p><strong>24. The differential case assembly is composed of two halves (a flanged and a plain) that are bolted together and supported by which type of bearing on either end?</strong></p>
+            <p><strong>The differential case assembly is composed of two halves (a flanged and a plain) that are bolted together and supported by which type of bearing on either end?</strong></p>
             <label><input type="radio" name="q24" value="a"> A. Ball bearings</label>
             <label><input type="radio" name="q24" value="b"> B. Straight roller bearings</label>
             <label><input type="radio" name="q24" value="c"> C. Tapered roller bearings</label>
@@ -262,7 +262,7 @@
         </div>
 
         <div class="question">
-            <p><strong>25. The crown gear is bolted to which specific component in the differential case assembly?</strong></p>
+            <p><strong>The crown gear is bolted to which specific component in the differential case assembly?</strong></p>
             <label><input type="radio" name="q25" value="a"> A. The plain case half</label>
             <label><input type="radio" name="q25" value="b"> B. The differential cross shaft</label>
             <label><input type="radio" name="q25" value="c"> C. The flanged differential case half</label>
@@ -270,7 +270,7 @@
         </div>
 
         <div class="question">
-            <p><strong>26. The differential cross shaft, often called the spider, is connected to and driven by:</strong></p>
+            <p><strong>The differential cross shaft, often called the spider, is connected to and driven by:</strong></p>
             <label><input type="radio" name="q26" value="a"> A. Splines on the axle shaft.</label>
             <label><input type="radio" name="q26" value="b"> B. The differential pinion gears.</label>
             <label><input type="radio" name="q26" value="c"> C. Recesses machined into the differential case halves.</label>
@@ -278,7 +278,7 @@
         </div>
 
         <div class="question">
-            <p><strong>27. What components are placed between the differential pinion gears and the differential case assembly?</strong></p>
+            <p><strong>What components are placed between the differential pinion gears and the differential case assembly?</strong></p>
             <label><input type="radio" name="q27" value="a"> A. Pinion position shims</label>
             <label><input type="radio" name="q27" value="b"> B. Thrust washers</label>
             <label><input type="radio" name="q27" value="c"> C. Bearing adjuster rings</label>
@@ -286,7 +286,7 @@
         </div>
 
         <div class="question">
-            <p><strong>28. The axle side gears are the final components in the differential case assembly and mate with the splines on each axle shaft. The axle side gears are in mesh with which other gears?</strong></p>
+            <p><strong>The axle side gears are the final components in the differential case assembly and mate with the splines on each axle shaft. The axle side gears are in mesh with which other gears?</strong></p>
             <label><input type="radio" name="q28" value="a"> A. The crown/ring gear</label>
             <label><input type="radio" name="q28" value="b"> B. The differential pinion gears</label>
             <label><input type="radio" name="q28" value="c"> C. The helical drive gear</label>
@@ -294,7 +294,7 @@
         </div>
 
         <div class="question">
-            <p><strong>29. If a vehicle equipped with a standard differential is turning a corner, what is the differential's function concerning torque delivery?</strong></p>
+            <p><strong>If a vehicle equipped with a standard differential is turning a corner, what is the differential's function concerning torque delivery?</strong></p>
             <label><input type="radio" name="q29" value="a"> A. Torque is increased to the wheel on the outside of the turn.</label>
             <label><input type="radio" name="q29" value="b"> B. Torque is transferred entirely to the wheel with the most traction.</label>
             <label><input type="radio" name="q29" value="c"> C. Torque is always divided equally between the two drive wheels.</label>
@@ -302,7 +302,7 @@
         </div>
 
         <div class="question">
-            <p><strong>30. The No-Spin traction control unit replaces which standard differential components?</strong></p>
+            <p><strong>The No-Spin traction control unit replaces which standard differential components?</strong></p>
             <label><input type="radio" name="q30" value="a"> A. The ring gear and differential case.</label>
             <label><input type="radio" name="q30" value="b"> B. The axle side gears and axle shafts.</label>
             <label><input type="radio" name="q30" value="c"> C. The standard cross shaft, differential pinions, and axle side gears.</label>
@@ -310,7 +310,7 @@
         </div>
 
         <div class="question">
-            <p><strong>31. In a No-Spin unit during normal locked operation, what component remains stationary relative to the rotating spider and driven clutch members?</strong></p>
+            <p><strong>In a No-Spin unit during normal locked operation, what component remains stationary relative to the rotating spider and driven clutch members?</strong></p>
             <label><input type="radio" name="q31" value="a"> A. The outer drive axle shaft.</label>
             <label><input type="radio" name="q31" value="b"> B. Nothing; all parts rotate at the same speed.</label>
             <label><input type="radio" name="q31" value="c"> C. The spring retainer.</label>
@@ -318,7 +318,7 @@
         </div>
 
         <div class="question">
-            <p><strong>32. What condition causes the driven clutch in a No-Spin unit to disengage (overrun) when a vehicle is turning a corner?</strong></p>
+            <p><strong>What condition causes the driven clutch in a No-Spin unit to disengage (overrun) when a vehicle is turning a corner?</strong></p>
             <label><input type="radio" name="q32" value="a"> A. The inner wheel rotates faster than the spider.</label>
             <label><input type="radio" name="q32" value="b"> B. The outer wheel travels faster than the inner wheel and has enough traction to drive the outer driven clutch faster than the spider.</label>
             <label><input type="radio" name="q32" value="c"> C. The operator applies the service brake.</label>
@@ -326,7 +326,7 @@
         </div>
 
         <div class="question">
-            <p><strong>33. What is the normal noise that occurs during the cornering process of a vehicle equipped with a No-Spin unit?</strong></p>
+            <p><strong>What is the normal noise that occurs during the cornering process of a vehicle equipped with a No-Spin unit?</strong></p>
             <label><input type="radio" name="q33" value="a"> A. A grinding sound indicating pinion gear failure.</label>
             <label><input type="radio" name="q33" value="b"> B. A steady howl indicative of backlash problems.</label>
             <label><input type="radio" name="q33" value="c"> C. A ratcheting noise due to the disengaging and engaging of the clutching teeth.</label>
@@ -334,7 +334,7 @@
         </div>
 
         <div class="question">
-            <p><strong>34. A Driver-Controlled Axle Differential Lock allows the operator to mechanically connect which two components together when poor traction is encountered?</strong></p>
+            <p><strong>A Driver-Controlled Axle Differential Lock allows the operator to mechanically connect which two components together when poor traction is encountered?</strong></p>
             <label><input type="radio" name="q34" value="a"> A. The drive pinion and the differential case.</label>
             <label><input type="radio" name="q34" value="b"> B. The axle shaft on one side and the differential case.</label>
             <label><input type="radio" name="q34" value="c"> C. The shift collar and the rear axle housing.</label>
@@ -342,7 +342,7 @@
         </div>
 
         <div class="question">
-            <p><strong>35. The Eaton driver-controlled wheel lock is typically operated by the driver using which two types of systems?</strong></p>
+            <p><strong>The Eaton driver-controlled wheel lock is typically operated by the driver using which two types of systems?</strong></p>
             <label><input type="radio" name="q35" value="a"> A. Hydraulic pressure or vacuum actuation.</label>
             <label><input type="radio" name="q35" value="b"> B. Mechanical cable or direct linkage.</label>
             <label><input type="radio" name="q35" value="c"> C. Air switch or an electric-over-air system.</label>
@@ -350,7 +350,7 @@
         </div>
 
         <div class="question">
-            <p><strong>36. Which heavy-duty application often requires the use of an Outboard Planetary Final Drive system?</strong></p>
+            <p><strong>Which heavy-duty application often requires the use of an Outboard Planetary Final Drive system?</strong></p>
             <label><input type="radio" name="q36" value="a"> A. Highway cruising vehicles with high fuel economy ratios.</label>
             <label><input type="radio" name="q36" value="b"> B. Medium-duty trucks operating primarily on smooth pavement.</label>
             <label><input type="radio" name="q36" value="c"> C. Heavy-duty trucks transporting heavy loads in an off-road environment.</label>
@@ -358,7 +358,7 @@
         </div>
 
         <div class="question">
-            <p><strong>37. In an Outboard Planetary Final Drive system, what is the role of the planetary carrier assembly?</strong></p>
+            <p><strong>In an Outboard Planetary Final Drive system, what is the role of the planetary carrier assembly?</strong></p>
             <label><input type="radio" name="q37" value="a"> A. It is the held member (stationary).</label>
             <label><input type="radio" name="q37" value="b"> B. It is the drive member (input).</label>
             <label><input type="radio" name="q37" value="c"> C. It is the output member, which is bolted to the hub assembly.</label>
@@ -366,7 +366,7 @@
         </div>
 
         <div class="question">
-            <p><strong>38. The internal gear (ring gear) in the Outboard Planetary Final Drive is the held member because it is splined to what fixed component?</strong></p>
+            <p><strong>The internal gear (ring gear) in the Outboard Planetary Final Drive is the held member because it is splined to what fixed component?</strong></p>
             <label><input type="radio" name="q38" value="a"> A. The hub assembly.</label>
             <label><input type="radio" name="q38" value="b"> B. The spindle.</label>
             <label><input type="radio" name="q38" value="c"> C. The sun gear.</label>
@@ -374,7 +374,7 @@
         </div>
 
         <div class="question">
-            <p><strong>39. The Inter-Axle Differential Assembly (Power Divider) is a differential that allows for speed differences to occur between the forward and rearward drive axle input pinions. This assembly is typically an integral part of which axle housing?</strong></p>
+            <p><strong>The Inter-Axle Differential Assembly (Power Divider) is a differential that allows for speed differences to occur between the forward and rearward drive axle input pinions. This assembly is typically an integral part of which axle housing?</strong></p>
             <label><input type="radio" name="q39" value="a"> A. The main transmission housing.</label>
             <label><input type="radio" name="q39" value="b"> B. The rear drive axle assembly.</label>
             <label><input type="radio" name="q39" value="c"> C. The front or intermediate drive axle assembly.</label>
@@ -382,7 +382,7 @@
         </div>
 
         <div class="question">
-            <p><strong>40. When the inter-axle differential is allowed to operate (lockout disengaged), how is torque divided between the two drive axle assemblies (forward and rearward)?</strong></p>
+            <p><strong>When the inter-axle differential is allowed to operate (lockout disengaged), how is torque divided between the two drive axle assemblies (forward and rearward)?</strong></p>
             <label><input type="radio" name="q40" value="a"> A. Torque is transferred entirely to the axle with the most traction.</label>
             <label><input type="radio" name="q40" value="b"> B. Torque is divided unevenly, favoring the forward axle.</label>
             <label><input type="radio" name="q40" value="c"> C. Torque is divided equally between the two drive axle assemblies.</label>
@@ -390,7 +390,7 @@
         </div>
 
         <div class="question">
-            <p><strong>41. What is the functional result of mechanically locking out the inter-axle differential (lockout engaged)?</strong></p>
+            <p><strong>What is the functional result of mechanically locking out the inter-axle differential (lockout engaged)?</strong></p>
             <label><input type="radio" name="q41" value="a"> A. The inter-axle differential action is temporarily eliminated, and the entire assembly turns as a solid unit.</label>
             <label><input type="radio" name="q41" value="b"> B. The torque is diverted entirely to the rearward drive axle.</label>
             <label><input type="radio" name="q41" value="c"> C. The truck enters a freewheeling condition.</label>
@@ -398,7 +398,7 @@
         </div>
 
         <div class="question">
-            <p><strong>42. Under what driving condition is it CAUTIONED against locking out the inter-axle differential?</strong></p>
+            <p><strong>Under what driving condition is it CAUTIONED against locking out the inter-axle differential?</strong></p>
             <label><input type="radio" name="q42" value="a"> A. Moving straight ahead at low speed on a slippery surface.</label>
             <label><input type="radio" name="q42" value="b"> B. Operating the truck on dry roads or turning the truck.</label>
             <label><input type="radio" name="q42" value="c"> C. Slowly approaching a stretch of road where traction is poor.</label>
@@ -406,7 +406,7 @@
         </div>
 
         <div class="question">
-            <p><strong>43. Which type of gear oil classification (API rating) is required for hypoid gear sets?</strong></p>
+            <p><strong>Which type of gear oil classification (API rating) is required for hypoid gear sets?</strong></p>
             <label><input type="radio" name="q43" value="a"> A. GL1</label>
             <label><input type="radio" name="q43" value="b"> B. GL3</label>
             <label><input type="radio" name="q43" value="c"> C. GL5</label>
@@ -414,7 +414,7 @@
         </div>
 
         <div class="question">
-            <p><strong>44. What is the fundamental disadvantage of mixing different types of gear oil in a drive axle housing?</strong></p>
+            <p><strong>What is the fundamental disadvantage of mixing different types of gear oil in a drive axle housing?</strong></p>
             <label><input type="radio" name="q44" value="a"> A. The lubricant's viscosity rating will increase dramatically.</label>
             <label><input type="radio" name="q44" value="b"> B. Mixing different types of gear oil causes a breakdown chemically.</label>
             <label><input type="radio" name="q44" value="c"> C. The oil will resist foaming under extreme temperature.</label>
@@ -422,7 +422,7 @@
         </div>
 
         <div class="question">
-            <p><strong>45. The full synthetic gear lubricants offer which specific benefit over traditional gear oils?</strong></p>
+            <p><strong>The full synthetic gear lubricants offer which specific benefit over traditional gear oils?</strong></p>
             <label><input type="radio" name="q45" value="a"> A. They maintain a lower cost per litre.</label>
             <label><input type="radio" name="q45" value="b"> B. They reduce bearing and gear distress only at high temperatures.</label>
             <label><input type="radio" name="q45" value="c"> C. They reduce bearing and gear distress under extreme operating conditions (high and low temperatures).</label>
@@ -430,7 +430,7 @@
         </div>
 
         <div class="question">
-            <p><strong>46. The vast majority of drive axle assemblies are lubricated using which basic system?</strong></p>
+            <p><strong>The vast majority of drive axle assemblies are lubricated using which basic system?</strong></p>
             <label><input type="radio" name="q46" value="a"> A. Dedicated pressure pump and filter system.</label>
             <label><input type="radio" name="q46" value="b"> B. Fluid transfer pump system.</label>
             <label><input type="radio" name="q46" value="c"> C. Splash lubrication system, where the crown gear moves through an oil reservoir.</label>
@@ -438,7 +438,7 @@
         </div>
 
         <div class="question">
-            <p><strong>47. Why do some manufacturers install a lube pump in the front or intermediate differential carrier assemblies on a tandem axle combination?</strong></p>
+            <p><strong>Why do some manufacturers install a lube pump in the front or intermediate differential carrier assemblies on a tandem axle combination?</strong></p>
             <label><input type="radio" name="q47" value="a"> A. To ensure the pinion bearings receive adequate lubrication when the axle is cold.</label>
             <label><input type="radio" name="q47" value="b"> B. To offer lubrication to the inter-axle differential assembly that cannot be reached by splash lubrication, especially during a wheel spin.</label>
             <label><input type="radio" name="q47" value="c"> C. To provide a high-pressure oil flow to the wheel ends.</label>
@@ -446,7 +446,7 @@
         </div>
 
         <div class="question">
-            <p><strong>48. If the differential is equipped with an oil pump, what filtration component is installed on the pickup to trap materials before the pump ingests them?</strong></p>
+            <p><strong>If the differential is equipped with an oil pump, what filtration component is installed on the pickup to trap materials before the pump ingests them?</strong></p>
             <label><input type="radio" name="q48" value="a"> A. Spin-on oil filter</label>
             <label><input type="radio" name="q48" value="b"> B. Magnetic screen</label>
             <label><input type="radio" name="q48" value="c"> C. Dedicated drain plug</label>
@@ -454,7 +454,7 @@
         </div>
 
         <div class="question">
-            <p><strong>49. When the drive pinion nut fails, which selective component must be recommended as a related sale?</strong></p>
+            <p><strong>When the drive pinion nut fails, which selective component must be recommended as a related sale?</strong></p>
             <label><input type="radio" name="q49" value="a"> A. Pinion position shim</label>
             <label><input type="radio" name="q49" value="b"> B. Differential cross shaft</label>
             <label><input type="radio" name="q49" value="c"> C. Crush sleeve</label>
@@ -462,7 +462,7 @@
         </div>
 
         <div class="question">
-            <p><strong>50. If a customer is ordering a remanufactured drive axle unit, what essential information must the parts technician relay to the customer regarding the old unit?</strong></p>
+            <p><strong>If a customer is ordering a remanufactured drive axle unit, what essential information must the parts technician relay to the customer regarding the old unit?</strong></p>
             <label><input type="radio" name="q50" value="a"> A. That all parts are guaranteed to be new and carry a lifetime warranty.</label>
             <label><input type="radio" name="q50" value="b"> B. That the customer will be charged a core charge and must return the old axle assembly (core) to receive a credit.</label>
             <label><input type="radio" name="q50" value="c"> C. That the unit will be shipped without bearings and seals.</label>

--- a/270202-test/270202k - Automatic Transmission Internal Operations.html
+++ b/270202-test/270202k - Automatic Transmission Internal Operations.html
@@ -70,7 +70,7 @@
 
 
 <div class="question">
-  <p><strong>1. Which gear set is used as the basic means of multiplying the twisting force (torque) from the engine to the driving wheels in the majority of modern automatic transmissions?</strong></p>
+  <p><strong>Which gear set is used as the basic means of multiplying the twisting force (torque) from the engine to the driving wheels in the majority of modern automatic transmissions?</strong></p>
   <label><input type="radio" name="q1" value="a"> A. Helical gear sets</label>
   <label><input type="radio" name="q1" value="b"> B. Hypoid gear sets</label>
   <label><input type="radio" name="q1" value="c"> C. Planetary gear sets</label>
@@ -78,7 +78,7 @@
 </div>
 
 <div class="question">
-  <p><strong>2. To achieve Direct Drive (1:1 ratio) in a simple planetary gear set, which of the following is required according to the laws of operation?</strong></p>
+  <p><strong>To achieve Direct Drive (1:1 ratio) in a simple planetary gear set, which of the following is required according to the laws of operation?</strong></p>
   <label><input type="radio" name="q2" value="a"> A. The sun gear must be held stationary by a band.</label>
   <label><input type="radio" name="q2" value="b"> B. The planetary carrier must be used as the input member.</label>
   <label><input type="radio" name="q2" value="c"> C. Two members must be locked together or driven at the same speed.</label>
@@ -86,7 +86,7 @@
 </div>
 
 <div class="question">
-  <p><strong>3. To transmit torque through any planetary gear system, regardless of its design, which three operational members must be present?</strong></p>
+  <p><strong>To transmit torque through any planetary gear system, regardless of its design, which three operational members must be present?</strong></p>
   <label><input type="radio" name="q3" value="a"> A. Sun gear, internal/ring gear, and planetary pinions.</label>
   <label><input type="radio" name="q3" value="b"> B. Drive member, held member, and freewheeling member.</label>
   <label><input type="radio" name="q3" value="c"> C. One input (drive) member, one output (driven) member, and one reaction (held) member.</label>
@@ -94,7 +94,7 @@
 </div>
 
 <div class="question">
-  <p><strong>4. A gear set arrangement that uses two simple planetary gear sets mounted on a common sun gear is known as the:</strong></p>
+  <p><strong>A gear set arrangement that uses two simple planetary gear sets mounted on a common sun gear is known as the:</strong></p>
   <label><input type="radio" name="q4" value="a"> A. Tandem set.</label>
   <label><input type="radio" name="q4" value="b"> B. Planetary reduction unit.</label>
   <label><input type="radio" name="q4" value="c"> C. Simpson gear set.</label>
@@ -102,7 +102,7 @@
 </div>
 
 <div class="question">
-  <p><strong>5. In a simple planetary gear set, if the Planetary Carrier is held, and the Sun Gear is used as the input member, what is the resulting output combination?</strong></p>
+  <p><strong>In a simple planetary gear set, if the Planetary Carrier is held, and the Sun Gear is used as the input member, what is the resulting output combination?</strong></p>
   <label><input type="radio" name="q5" value="a"> A. Forward Reduction</label>
   <label><input type="radio" name="q5" value="b"> B. Reverse Overdrive</label>
   <label><input type="radio" name="q5" value="c"> C. Reverse Reduction</label>
@@ -110,7 +110,7 @@
 </div>
 
 <div class="question">
-  <p><strong>6. If a simple planetary gear set is configured for Forward Deep Reduction, which member is held stationary?</strong></p>
+  <p><strong>If a simple planetary gear set is configured for Forward Deep Reduction, which member is held stationary?</strong></p>
   <label><input type="radio" name="q6" value="a"> A. Sun Gear</label>
   <label><input type="radio" name="q6" value="b"> B. Planet Carrier</label>
   <label><input type="radio" name="q6" value="c"> C. Internal/Ring Gear</label>
@@ -118,7 +118,7 @@
 </div>
 
 <div class="question">
-  <p><strong>7. To achieve Forward Long Overdrive in a simple planetary gear set, the Internal/Ring Gear is held stationary. Which member must serve as the input member?</strong></p>
+  <p><strong>To achieve Forward Long Overdrive in a simple planetary gear set, the Internal/Ring Gear is held stationary. Which member must serve as the input member?</strong></p>
   <label><input type="radio" name="q7" value="a"> A. Sun Gear</label>
   <label><input type="radio" name="q7" value="b"> B. Planet Carrier</label>
   <label><input type="radio" name="q7" value="c"> C. Input Shaft</label>
@@ -126,7 +126,7 @@
 </div>
 
 <div class="question">
-  <p><strong>8. In a simple planetary gear set, if the Sun Gear is held stationary and the Internal/Ring Gear is used as the input member, which member serves as the output, providing Forward Reduction?</strong></p>
+  <p><strong>In a simple planetary gear set, if the Sun Gear is held stationary and the Internal/Ring Gear is used as the input member, which member serves as the output, providing Forward Reduction?</strong></p>
   <label><input type="radio" name="q8" value="a"> A. Sun Gear Shaft</label>
   <label><input type="radio" name="q8" value="b"> B. Rear Internal Gear</label>
   <label><input type="radio" name="q8" value="c"> C. Planet Carrier</label>
@@ -134,7 +134,7 @@
 </div>
 
 <div class="question">
-  <p><strong>9. What is the resulting operational condition in a simple planetary gear set if there is no held member and no drive member?</strong></p>
+  <p><strong>What is the resulting operational condition in a simple planetary gear set if there is no held member and no drive member?</strong></p>
   <label><input type="radio" name="q9" value="a"> A. Direct Drive</label>
   <label><input type="radio" name="q9" value="b"> B. Forward Deep Reduction</label>
   <label><input type="radio" name="q9" value="c"> C. Neutral</label>
@@ -142,7 +142,7 @@
 </div>
 
 <div class="question">
-  <p><strong>10. If the Planet Carrier is held stationary and the Ring Gear is used as the input, what member provides the output for Reverse Overdrive?</strong></p>
+  <p><strong>If the Planet Carrier is held stationary and the Ring Gear is used as the input, what member provides the output for Reverse Overdrive?</strong></p>
   <label><input type="radio" name="q10" value="a"> A. Planetary Pinions</label>
   <label><input type="radio" name="q10" value="b"> B. Sun Gear</label>
   <label><input type="radio" name="q10" value="c"> C. Output Shaft</label>
@@ -150,7 +150,7 @@
 </div>
 
 <div class="question">
-  <p><strong>11. Planetary gear sets are designed to handle large torque loads for their size primarily because of what characteristic?</strong></p>
+  <p><strong>Planetary gear sets are designed to handle large torque loads for their size primarily because of what characteristic?</strong></p>
   <label><input type="radio" name="q11" value="a"> A. They use spur gears to reduce end thrust.</label>
   <label><input type="radio" name="q11" value="b"> B. The torque load is distributed over several planet pinion gears, providing more teeth in contact.</label>
   <label><input type="radio" name="q11" value="c"> C. They utilize a double-acting servo to apply the clutch.</label>
@@ -158,7 +158,7 @@
 </div>
 
 <div class="question">
-  <p><strong>12. The gears in a planetary set are considered to be in constant mesh. What primary benefit does this provide?</strong></p>
+  <p><strong>The gears in a planetary set are considered to be in constant mesh. What primary benefit does this provide?</strong></p>
   <label><input type="radio" name="q12" value="a"> A. Enables the use of external tooth gears only.</label>
   <label><input type="radio" name="q12" value="b"> B. Allows for instantaneous servo application.</label>
   <label><input type="radio" name="q12" value="c"> C. Helps eliminate gear damage from gear clash when shifting gears.</label>
@@ -166,7 +166,7 @@
 </div>
 
 <div class="question">
-  <p><strong>13. The internal/ring gear is meshed with the planetary pinions. When the external tooth planetary pinions rotate inside the internal tooth ring gear, how do they rotate relative to each other?</strong></p>
+  <p><strong>The internal/ring gear is meshed with the planetary pinions. When the external tooth planetary pinions rotate inside the internal tooth ring gear, how do they rotate relative to each other?</strong></p>
   <label><input type="radio" name="q13" value="a"> A. In opposite directions.</label>
   <label><input type="radio" name="q13" value="b"> B. Only during deep reduction.</label>
   <label><input type="radio" name="q13" value="c"> C. In the same direction.</label>
@@ -174,7 +174,7 @@
 </div>
 
 <div class="question">
-  <p><strong>14. What operational state is achieved in a simple planetary gear set when the Sun Gear is held stationary, and the Planet Carrier is the input member?</strong></p>
+  <p><strong>What operational state is achieved in a simple planetary gear set when the Sun Gear is held stationary, and the Planet Carrier is the input member?</strong></p>
   <label><input type="radio" name="q14" value="a"> A. Reverse Reduction</label>
   <label><input type="radio" name="q14" value="b"> B. Forward Overdrive</label>
   <label><input type="radio" name="q14" value="c"> C. Forward Deep Reduction</label>
@@ -182,7 +182,7 @@
 </div>
 
 <div class="question">
-  <p><strong>15. What are the two types of clutches used to control planetary gear train assemblies in an automatic transmission?</strong></p>
+  <p><strong>What are the two types of clutches used to control planetary gear train assemblies in an automatic transmission?</strong></p>
   <label><input type="radio" name="q15" value="a"> A. Clutch brake and centrifugal clutch.</label>
   <label><input type="radio" name="q15" value="b"> B. Multiple-disc mechanical and overrunning mechanical.</label>
   <label><input type="radio" name="q15" value="c"> C. Overrunning (one-way) clutches and multiple-disc hydraulic clutches.</label>
@@ -190,7 +190,7 @@
 </div>
 
 <div class="question">
-  <p><strong>16. Which type of clutch is referred to as a wet-type clutch because it operates in automatic transmission fluid?</strong></p>
+  <p><strong>Which type of clutch is referred to as a wet-type clutch because it operates in automatic transmission fluid?</strong></p>
   <label><input type="radio" name="q16" value="a"> A. Overrunning clutch</label>
   <label><input type="radio" name="q16" value="b"> B. Sprag clutch</label>
   <label><input type="radio" name="q16" value="c"> C. Multiple-disc hydraulic clutch assembly</label>
@@ -198,7 +198,7 @@
 </div>
 
 <div class="question">
-  <p><strong>17. Which statement accurately describes the operation of overrunning (one-way) clutches?</strong></p>
+  <p><strong>Which statement accurately describes the operation of overrunning (one-way) clutches?</strong></p>
   <label><input type="radio" name="q17" value="a"> A. They require continuous hydraulic controls for holding and freewheeling.</label>
   <label><input type="radio" name="q17" value="b"> B. They require periodic adjustment to maintain holding capacity.</label>
   <label><input type="radio" name="q17" value="c"> C. They are mechanically applied and released, which requires no hydraulic controls for their operation.</label>
@@ -206,7 +206,7 @@
 </div>
 
 <div class="question">
-  <p><strong>18. What is the explicit functional purpose of the freewheeling action of a one-way clutch?</strong></p>
+  <p><strong>What is the explicit functional purpose of the freewheeling action of a one-way clutch?</strong></p>
   <label><input type="radio" name="q18" value="a"> A. To hold a member of the planetary gear set to the case.</label>
   <label><input type="radio" name="q18" value="b"> B. To improve shift quality by eliminating a timing problem during band-to-band or band-to-clutch shifts.</label>
   <label><input type="radio" name="q18" value="c"> C. To provide a high degree of frictional drag in the overrun mode.</label>
@@ -214,7 +214,7 @@
 </div>
 
 <div class="question">
-  <p><strong>19. In a multiple-disc clutch assembly, the steel plates are generally splined to which component?</strong></p>
+  <p><strong>In a multiple-disc clutch assembly, the steel plates are generally splined to which component?</strong></p>
   <label><input type="radio" name="q19" value="a"> A. The center hub</label>
   <label><input type="radio" name="q19" value="b"> B. The clutch piston</label>
   <label><input type="radio" name="q19" value="c"> C. The clutch drum or the transmission case</label>
@@ -222,7 +222,7 @@
 </div>
 
 <div class="question">
-  <p><strong>20. What determines the torque capacity or torque-holding capacity of a multiple-disc clutch pack assembly?</strong></p>
+  <p><strong>What determines the torque capacity or torque-holding capacity of a multiple-disc clutch pack assembly?</strong></p>
   <label><input type="radio" name="q20" value="a"> A. The pressure of the return spring.</label>
   <label><input type="radio" name="q20" value="b"> B. The number of contacting surfaces (clutch plates and friction discs).</label>
   <label><input type="radio" name="q20" value="c"> C. The amount of residual oil in the drum.</label>
@@ -230,7 +230,7 @@
 </div>
 
 <div class="question">
-  <p><strong>21. What component is stacked alternately with steel plates to make up a clutch pack?</strong></p>
+  <p><strong>What component is stacked alternately with steel plates to make up a clutch pack?</strong></p>
   <label><input type="radio" name="q21" value="a"> A. Waved snap rings</label>
   <label><input type="radio" name="q21" value="b"> B. Composition-faced (friction) plates</label>
   <label><input type="radio" name="q21" value="c"> C. Reaction plates</label>
@@ -238,7 +238,7 @@
 </div>
 
 <div class="question">
-  <p><strong>22. When a multiple-disc clutch is applied, what component compresses the plates, providing a drive between the drum and hub?</strong></p>
+  <p><strong>When a multiple-disc clutch is applied, what component compresses the plates, providing a drive between the drum and hub?</strong></p>
   <label><input type="radio" name="q22" value="a"> A. The wave plate</label>
   <label><input type="radio" name="q22" value="b"> B. The return spring</label>
   <label><input type="radio" name="q22" value="c"> C. The apply piston</label>
@@ -246,7 +246,7 @@
 </div>
 
 <div class="question">
-  <p><strong>23. Some clutches use a waved steel plate in the clutch pack. What is the specific function of this plate?</strong></p>
+  <p><strong>Some clutches use a waved steel plate in the clutch pack. What is the specific function of this plate?</strong></p>
   <label><input type="radio" name="q23" value="a"> A. To secure the friction plates to the hub.</label>
   <label><input type="radio" name="q23" value="b"> B. To act as a cushioning device.</label>
   <label><input type="radio" name="q23" value="c"> C. To lock the clutch drum to the case.</label>
@@ -254,7 +254,7 @@
 </div>
 
 <div class="question">
-  <p><strong>24. The friction material used on clutch plates is made of which types of materials?</strong></p>
+  <p><strong>The friction material used on clutch plates is made of which types of materials?</strong></p>
   <label><input type="radio" name="q24" value="a"> A. Sintered bronze or aluminum alloy.</label>
   <label><input type="radio" name="q24" value="b"> B. Semi-metallic or paper cellulose material.</label>
   <label><input type="radio" name="q24" value="c"> C. Cast iron or Teflon.</label>
@@ -262,7 +262,7 @@
 </div>
 
 <div class="question">
-  <p><strong>25. The clutch friction plates are typically splined on the inner circumference to mesh with splines on which component?</strong></p>
+  <p><strong>The clutch friction plates are typically splined on the inner circumference to mesh with splines on which component?</strong></p>
   <label><input type="radio" name="q25" value="a"> A. The clutch drum or housing.</label>
   <label><input type="radio" name="q25" value="b"> B. The servo piston.</label>
   <label><input type="radio" name="q25" value="c"> C. The center hub of the member to which they are attached.</label>
@@ -270,7 +270,7 @@
 </div>
 
 <div class="question">
-  <p><strong>26. Most hydraulic clutches are applied by pressurized fluid and released by what component?</strong></p>
+  <p><strong>Most hydraulic clutches are applied by pressurized fluid and released by what component?</strong></p>
   <label><input type="radio" name="q26" value="a"> A. An accumulator</label>
   <label><input type="radio" name="q26" value="b"> B. A spring or springs</label>
   <label><input type="radio" name="q26" value="c"> C. A pressure regulator valve</label>
@@ -278,7 +278,7 @@
 </div>
 
 <div class="question">
-  <p><strong>27. What component prevents oil leakage between the stationary clutch support and a rotating clutch drum when hydraulic pressure is applied?</strong></p>
+  <p><strong>What component prevents oil leakage between the stationary clutch support and a rotating clutch drum when hydraulic pressure is applied?</strong></p>
   <label><input type="radio" name="q27" value="a"> A. Clutch apply piston</label>
   <label><input type="radio" name="q27" value="b"> B. Cast iron or Teflon seal rings</label>
   <label><input type="radio" name="q27" value="c"> C. Friction plates</label>
@@ -286,7 +286,7 @@
 </div>
 
 <div class="question">
-  <p><strong>28. Seal rings provide efficient sealing primarily due to a built-in tension or expansion force that ensures what initial condition?</strong></p>
+  <p><strong>Seal rings provide efficient sealing primarily due to a built-in tension or expansion force that ensures what initial condition?</strong></p>
   <label><input type="radio" name="q28" value="a"> A. The fluid is restricted by the restrictive orifice.</label>
   <label><input type="radio" name="q28" value="b"> B. Initial contact with the bore.</label>
   <label><input type="radio" name="q28" value="c"> C. The fluid pressure is equalized on both sides of the clutch.</label>
@@ -294,7 +294,7 @@
 </div>
 
 <div class="question">
-  <p><strong>29. A Scarf Cut refers to which characteristic of a Teflon seal ring?</strong></p>
+  <p><strong>A Scarf Cut refers to which characteristic of a Teflon seal ring?</strong></p>
   <label><input type="radio" name="q29" value="a"> A. A coarse finish on the edge left from manufacturing.</label>
   <label><input type="radio" name="q29" value="b"> B. The ends are cut on an angle.</label>
   <label><input type="radio" name="q29" value="c"> C. A square-cut end on a cast iron seal.</label>
@@ -302,7 +302,7 @@
 </div>
 
 <div class="question">
-  <p><strong>30. Cast iron seal rings are distinguished by always having an opening, which may be secured by which two types of ends?</strong></p>
+  <p><strong>Cast iron seal rings are distinguished by always having an opening, which may be secured by which two types of ends?</strong></p>
   <label><input type="radio" name="q30" value="a"> A. One-piece or lathe-cut.</label>
   <label><input type="radio" name="q30" value="b"> B. Square-cut (butt joint) or interlocking hooks.</label>
   <label><input type="radio" name="q30" value="c"> C. Round O-ring or D-cut O-ring.</label>
@@ -310,7 +310,7 @@
 </div>
 
 <div class="question">
-  <p><strong>31. Lathe-cut seals are always one-piece seals made of neoprene or Viton. What unique feature of their edge aids in providing a tight seal?</strong></p>
+  <p><strong>Lathe-cut seals are always one-piece seals made of neoprene or Viton. What unique feature of their edge aids in providing a tight seal?</strong></p>
   <label><input type="radio" name="q31" value="a"> A. The interlocking hooked ends.</label>
   <label><input type="radio" name="q31" value="b"> B. The ability to freewheel in the overrun mode.</label>
   <label><input type="radio" name="q31" value="c"> C. A coarse finish left over from the manufacturing process.</label>
@@ -318,7 +318,7 @@
 </div>
 
 <div class="question">
-  <p><strong>32. The clutch drum, which houses the complete clutch assembly, may be made of which three materials?</strong></p>
+  <p><strong>The clutch drum, which houses the complete clutch assembly, may be made of which three materials?</strong></p>
   <label><input type="radio" name="q32" value="a"> A. Steel plate, neoprene, or Teflon.</label>
   <label><input type="radio" name="q32" value="b"> B. Cast iron, aluminum, or lightweight stamped steel.</label>
   <label><input type="radio" name="q32" value="c"> C. Brass, bronze, or copper.</label>
@@ -326,7 +326,7 @@
 </div>
 
 <div class="question">
-  <p><strong>33. How are clutch pistons applied and released?</strong></p>
+  <p><strong>How are clutch pistons applied and released?</strong></p>
   <label><input type="radio" name="q33" value="a"> A. Applied by spring force and released by centrifugal force.</label>
   <label><input type="radio" name="q33" value="b"> B. Applied by mainline oil pressure and released by a spring or springs.</label>
   <label><input type="radio" name="q33" value="c"> C. Applied by an accumulator and released by a servo piston.</label>
@@ -334,7 +334,7 @@
 </div>
 
 <div class="question">
-  <p><strong>34. A single Belleville type return spring provides an additional purpose besides returning the piston. What is this purpose?</strong></p>
+  <p><strong>A single Belleville type return spring provides an additional purpose besides returning the piston. What is this purpose?</strong></p>
   <label><input type="radio" name="q34" value="a"> A. To accommodate the short stroking distance required to apply the clutch.</label>
   <label><input type="radio" name="q34" value="b"> B. To eliminate the need for a pressure plate.</label>
   <label><input type="radio" name="q34" value="c"> C. It provides a mechanical advantage lever system for applying the clutch.</label>
@@ -342,7 +342,7 @@
 </div>
 
 <div class="question">
-  <p><strong>35. What is the function of the small steel ball-type check valve found in some clutch pistons or drums?</strong></p>
+  <p><strong>What is the function of the small steel ball-type check valve found in some clutch pistons or drums?</strong></p>
   <label><input type="radio" name="q35" value="a"> A. To restrict fluid flow to the clutch plates.</label>
   <label><input type="radio" name="q35" value="b"> B. To lock the clutch drum to the transmission case.</label>
   <label><input type="radio" name="q35" value="c"> C. To allow residual oil to escape when the clutch is released and turning at high RPM.</label>
@@ -350,7 +350,7 @@
 </div>
 
 <div class="question">
-  <p><strong>36. Without the clutch relief check valve, why might the clutch become partially applied during high RPM rotation when released?</strong></p>
+  <p><strong>Without the clutch relief check valve, why might the clutch become partially applied during high RPM rotation when released?</strong></p>
   <label><input type="radio" name="q36" value="a"> A. The accumulator would fail to cushion the shift.</label>
   <label><input type="radio" name="q36" value="b"> B. Residual oil would be forced outward by the centrifugal force of the rotating clutch.</label>
   <label><input type="radio" name="q36" value="c"> C. The mainline oil pressure would override the return spring force.</label>
@@ -358,7 +358,7 @@
 </div>
 
 <div class="question">
-  <p><strong>37. Which of the following is NOT listed as a device used to smooth the engagement (cushion the shock) of clutch assemblies?</strong></p>
+  <p><strong>Which of the following is NOT listed as a device used to smooth the engagement (cushion the shock) of clutch assemblies?</strong></p>
   <label><input type="radio" name="q37" value="a"> A. Waved snap rings</label>
   <label><input type="radio" name="q37" value="b"> B. Rubber cushion ring</label>
   <label><input type="radio" name="q37" value="c"> C. Accumulator</label>
@@ -366,7 +366,7 @@
 </div>
 
 <div class="question">
-  <p><strong>38. How does a waved snap ring help eliminate some of the harshness of a clutch apply?</strong></p>
+  <p><strong>How does a waved snap ring help eliminate some of the harshness of a clutch apply?</strong></p>
   <label><input type="radio" name="q38" value="a"> A. It acts as a pressure regulator to reduce mainline pressure.</label>
   <label><input type="radio" name="q38" value="b"> B. Its straightening or flattening action is compressed flat, allowing full pressure to build within the clutch.</label>
   <label><input type="radio" name="q38" value="c"> C. It allows for the controlled escape of oil and vapour during engagement.</label>
@@ -374,7 +374,7 @@
 </div>
 
 <div class="question">
-  <p><strong>39. An accumulator functions in the clutch apply circuit to control harshness or aggressiveness. How is the accumulator specifically classified relative to the clutch assembly?</strong></p>
+  <p><strong>An accumulator functions in the clutch apply circuit to control harshness or aggressiveness. How is the accumulator specifically classified relative to the clutch assembly?</strong></p>
   <label><input type="radio" name="q39" value="a"> A. As a type of clutch piston.</label>
   <label><input type="radio" name="q39" value="b"> B. As a type of Belleville spring.</label>
   <label><input type="radio" name="q39" value="c"> C. It is not an integral part of the clutch assembly.</label>
@@ -382,7 +382,7 @@
 </div>
 
 <div class="question">
-  <p><strong>40. How does a piston type accumulator cushion the application of a clutch?</strong></p>
+  <p><strong>How does a piston type accumulator cushion the application of a clutch?</strong></p>
   <label><input type="radio" name="q40" value="a"> A. By restricting the flow of oil through a filter mesh.</label>
   <label><input type="radio" name="q40" value="b"> B. By instantly reversing the oil flow.</label>
   <label><input type="radio" name="q40" value="c"> C. It absorbs fluid as the piston strokes, making pressure buildup more gradual and clutch engagement smooth.</label>
@@ -390,7 +390,7 @@
 </div>
 
 <div class="question">
-  <p><strong>41. What is the fundamental role of a transmission band?</strong></p>
+  <p><strong>What is the fundamental role of a transmission band?</strong></p>
   <label><input type="radio" name="q41" value="a"> A. To provide driving torque to the planetary gear set.</label>
   <label><input type="radio" name="q41" value="b"> B. To act as a flexible contracting brake assembly that is always used as a holding (reaction) member.</label>
   <label><input type="radio" name="q41" value="c"> C. To provide a permanent 1:1 ratio once the coupling point is reached.</label>
@@ -398,7 +398,7 @@
 </div>
 
 <div class="question">
-  <p><strong>42. What characteristics of a transmission band primarily determine its holding ability?</strong></p>
+  <p><strong>What characteristics of a transmission band primarily determine its holding ability?</strong></p>
   <label><input type="radio" name="q42" value="a"> A. The diameter of the drum it surrounds and the coefficient of friction.</label>
   <label><input type="radio" name="q42" value="b"> B. The length and width of the band and the amount of force applied against the band's anchored end.</label>
   <label><input type="radio" name="q42" value="c"> C. The thickness of the band and the frequency of adjustment.</label>
@@ -406,7 +406,7 @@
 </div>
 
 <div class="question">
-  <p><strong>43. Which design feature allows the transmission band to be applied with less hydraulic pressure?</strong></p>
+  <p><strong>Which design feature allows the transmission band to be applied with less hydraulic pressure?</strong></p>
   <label><input type="radio" name="q43" value="a"> A. The use of a double-wrap design only.</label>
   <label><input type="radio" name="q43" value="b"> B. The self-disengagement characteristic.</label>
   <label><input type="radio" name="q43" value="c"> C. The apply servo is mounted so that force is applied in the same direction as the drum rotation.</label>
@@ -414,7 +414,7 @@
 </div>
 
 <div class="question">
-  <p><strong>44. Which type of band design provides greater holding ability due to the self-energizing or wrap-around action of its connecting segments?</strong></p>
+  <p><strong>Which type of band design provides greater holding ability due to the self-energizing or wrap-around action of its connecting segments?</strong></p>
   <label><input type="radio" name="q44" value="a"> A. Single-wrap band</label>
   <label><input type="radio" name="q44" value="b"> B. Steel strap band</label>
   <label><input type="radio" name="q44" value="c"> C. Double-wrap band</label>
@@ -422,7 +422,7 @@
 </div>
 
 <div class="question">
-  <p><strong>45. The friction lining of a transmission band is either semi-metallic or organic. In most applications, when the band is used to hold a stationary drum (Manual Low (L1) or Reverse (R)), which friction material is used?</strong></p>
+  <p><strong>The friction lining of a transmission band is either semi-metallic or organic. In most applications, when the band is used to hold a stationary drum (Manual Low (L1) or Reverse (R)), which friction material is used?</strong></p>
   <label><input type="radio" name="q45" value="a"> A. Organic (paper pulp or cellulose).</label>
   <label><input type="radio" name="q45" value="b"> B. Semi-metallic material (can withstand high unit pressures).</label>
   <label><input type="radio" name="q45" value="c"> C. Rubber cushion ring.</label>
@@ -430,7 +430,7 @@
 </div>
 
 <div class="question">
-  <p><strong>46. What component is a hydraulically operated piston used to convert hydraulic pressure into mechanical force to apply a band within a transmission?</strong></p>
+  <p><strong>What component is a hydraulically operated piston used to convert hydraulic pressure into mechanical force to apply a band within a transmission?</strong></p>
   <label><input type="radio" name="q46" value="a"> A. An accumulator</label>
   <label><input type="radio" name="q46" value="b"> B. A check valve</label>
   <label><input type="radio" name="q46" value="c"> C. A servo assembly</label>
@@ -438,7 +438,7 @@
 </div>
 
 <div class="question">
-  <p><strong>47. Single-acting servos (simple servo design) are generally used for which applications?</strong></p>
+  <p><strong>Single-acting servos (simple servo design) are generally used for which applications?</strong></p>
   <label><input type="radio" name="q47" value="a"> A. Those that involve a timed band release during upshifts.</label>
   <label><input type="radio" name="q47" value="b"> B. Those that require a very large mechanical advantage.</label>
   <label><input type="radio" name="q47" value="c"> C. Applications that do not involve automatic upshifts or timed band releases, such as Manual Low (ML) or Reverse (R).</label>
@@ -446,7 +446,7 @@
 </div>
 
 <div class="question">
-  <p><strong>48. A Double-Acting Servo (Compound Servo Design) releases the band when hydraulic pressure is sent to the release side (spring side) of the piston. What is the state of the apply pressure during this release?</strong></p>
+  <p><strong>A Double-Acting Servo (Compound Servo Design) releases the band when hydraulic pressure is sent to the release side (spring side) of the piston. What is the state of the apply pressure during this release?</strong></p>
   <label><input type="radio" name="q48" value="a"> A. Apply pressure is shut off completely.</label>
   <label><input type="radio" name="q48" value="b"> B. Apply pressure remains on the apply side of the servo piston.</label>
   <label><input type="radio" name="q48" value="c"> C. Release pressure is less than the apply pressure.</label>
@@ -454,7 +454,7 @@
 </div>
 
 <div class="question">
-  <p><strong>49. What is the classification of clutch plates listed as a common replacement component when a clutch assembly fails?</strong></p>
+  <p><strong>What is the classification of clutch plates listed as a common replacement component when a clutch assembly fails?</strong></p>
   <label><input type="radio" name="q49" value="a"> A. Waved steel plates</label>
   <label><input type="radio" name="q49" value="b"> B. Clutch plates</label>
   <label><input type="radio" name="q49" value="c"> C. Thrust bearings</label>
@@ -462,7 +462,7 @@
 </div>
 
 <div class="question">
-  <p><strong>50. When a band fails, which component is listed as a related sales item?</strong></p>
+  <p><strong>When a band fails, which component is listed as a related sales item?</strong></p>
   <label><input type="radio" name="q50" value="a"> A. Clutch plates</label>
   <label><input type="radio" name="q50" value="b"> B. Seals</label>
   <label><input type="radio" name="q50" value="c"> C. Transmission filter</label>

--- a/assets/js/chat.js
+++ b/assets/js/chat.js
@@ -181,9 +181,13 @@
         return this.userProfiles[username];
       }
 
-      // Fallback to AvatarUtil or generated avatar
-      if (typeof window.AvatarUtil !== 'undefined') {
-        return window.AvatarUtil.getAvatarUrl(username);
+      // For current user only, check AvatarUtil (it uses localStorage which is user-specific)
+      var currentUsername = this.getUsername();
+      if (username === currentUsername && typeof window.AvatarUtil !== 'undefined') {
+        var avatarUrl = window.AvatarUtil.getAvatarUrl(username);
+        if (avatarUrl) {
+          return avatarUrl;
+        }
       }
 
       // Generate unique avatar based on username with unique color


### PR DESCRIPTION
- Fixed bug where other users' messages showed the current user's profile picture instead of their own. The AvatarUtil was returning localStorage data (user-specific) for all username lookups.
- Now AvatarUtil is only used for the current user; other users get unique generated avatars based on their username hash.
- Also removed numbered questions from 270202d test file.