### PR TITLE
Remove timers, fix answer letters, add chat to exams

### DIFF
--- a/270202-test/270202g - Light-Duty Drive Axle Assemblies.html
+++ b/270202-test/270202g - Light-Duty Drive Axle Assemblies.html
@@ -73,950 +73,950 @@
         <p><strong>What is the primary function of drive axle gear sets, regardless of whether they are used in a transaxle, RWD, AWD, or 4WD vehicle?</strong></p>
         <label>
           <input type="radio" name="q1" value="a">
-          A. To ensure both drive wheels turn at the same speed while cornering.
+          To ensure both drive wheels turn at the same speed while cornering.
         </label>
         <label>
           <input type="radio" name="q1" value="b">
-          B. To prevent the drive axle assembly from ballooning due to pressure changes.
+          To prevent the drive axle assembly from ballooning due to pressure changes.
         </label>
         <label>
           <input type="radio" name="q1" value="c">
-          C. To provide a final gear reduction resulting in a torque increase and a speed decrease.
+          To provide a final gear reduction resulting in a torque increase and a speed decrease.
         </label>
         <label>
           <input type="radio" name="q1" value="d">
-          D. To always change the direction of power flow by 90 ° .
+          To always change the direction of power flow by 90 ° .
         </label>
       </div>
       <div class="question">
         <p><strong>In rear-wheel drive (RWD) and four-wheel drive (4WD) drive axle assemblies, which type of gear set is most commonly used for the ring gear and drive pinion?</strong></p>
         <label>
           <input type="radio" name="q2" value="a">
-          A. Helical gears
+          Helical gears
         </label>
         <label>
           <input type="radio" name="q2" value="b">
-          B. Bevelled spur gears
+          Bevelled spur gears
         </label>
         <label>
           <input type="radio" name="q2" value="c">
-          C. Hypoid gears
+          Hypoid gears
         </label>
         <label>
           <input type="radio" name="q2" value="d">
-          D. Amboid gears
+          Amboid gears
         </label>
       </div>
       <div class="question">
         <p><strong>The design of a hypoid gear set allows the driveshaft to be lowered, thereby lowering the overall vehicle profile. This is achieved because the drive pinion shaft centerline is located:</strong></p>
         <label>
           <input type="radio" name="q3" value="a">
-          A. In the same plane as the ring gear centerline.
+          In the same plane as the ring gear centerline.
         </label>
         <label>
           <input type="radio" name="q3" value="b">
-          B. Above the ring gear centerline (Amboid design).
+          Above the ring gear centerline (Amboid design).
         </label>
         <label>
           <input type="radio" name="q3" value="c">
-          C. Below the ring gear centerline.
+          Below the ring gear centerline.
         </label>
         <label>
           <input type="radio" name="q3" value="d">
-          D. At a 90 ° angle to the output rotation.
+          At a 90 ° angle to the output rotation.
         </label>
       </div>
       <div class="question">
         <p><strong>What is the consequence of the large curvature of the gear teeth in a hypoid gear set?</strong></p>
         <label>
           <input type="radio" name="q4" value="a">
-          A. It eliminates the need for lubrication.
+          It eliminates the need for lubrication.
         </label>
         <label>
           <input type="radio" name="q4" value="b">
-          B. It allows the gear set to operate quietly with zero side thrust.
+          It allows the gear set to operate quietly with zero side thrust.
         </label>
         <label>
           <input type="radio" name="q4" value="c">
-          C. It causes a great deal of side thrust.
+          It causes a great deal of side thrust.
         </label>
         <label>
           <input type="radio" name="q4" value="d">
-          D. It allows the gear teeth to be fully engaged at all times.
+          It allows the gear teeth to be fully engaged at all times.
         </label>
       </div>
       <div class="question">
         <p><strong>Which gear type, shaped like truncated cones for strength, is characterized by producing thrust as the gears want to separate when torque is applied, making them suitable for use in the differential assembly?</strong></p>
         <label>
           <input type="radio" name="q5" value="a">
-          A. Helical gears
+          Helical gears
         </label>
         <label>
           <input type="radio" name="q5" value="b">
-          B. Straight-cut bevel gears
+          Straight-cut bevel gears
         </label>
         <label>
           <input type="radio" name="q5" value="c">
-          C. Hypoid gears
+          Hypoid gears
         </label>
         <label>
           <input type="radio" name="q5" value="d">
-          D. Spur gears
+          Spur gears
         </label>
       </div>
       <div class="question">
         <p><strong>What gear type is typically used in the differential unit as the differential pinion gears and axle or side gears?</strong></p>
         <label>
           <input type="radio" name="q6" value="a">
-          A. Hypoid gears
+          Hypoid gears
         </label>
         <label>
           <input type="radio" name="q6" value="b">
-          B. Straight-cut bevel gears
+          Straight-cut bevel gears
         </label>
         <label>
           <input type="radio" name="q6" value="c">
-          C. Bevelled spur gears
+          Bevelled spur gears
         </label>
         <label>
           <input type="radio" name="q6" value="d">
-          D. Double offset joints
+          Double offset joints
         </label>
       </div>
       <div class="question">
         <p><strong>The primary reason bevelled spur gears (used in the differential) are considered a relatively weak gear set is that:</strong></p>
         <label>
           <input type="radio" name="q7" value="a">
-          A. They produce excessive side thrust.
+          They produce excessive side thrust.
         </label>
         <label>
           <input type="radio" name="q7" value="b">
-          B. They are only used in non-traction-enhancing differentials.
+          They are only used in non-traction-enhancing differentials.
         </label>
         <label>
           <input type="radio" name="q7" value="c">
-          C. Only one tooth of a spur gear set is fully engaged at a time, resulting in a small load contact area.
+          Only one tooth of a spur gear set is fully engaged at a time, resulting in a small load contact area.
         </label>
         <label>
           <input type="radio" name="q7" value="d">
-          D. They are made of soft, stamped steel that is not induction hardened.
+          They are made of soft, stamped steel that is not induction hardened.
         </label>
       </div>
       <div class="question">
         <p><strong>In a transverse-mounted transaxle assembly, which uses helical drive axle gears, what is the required change in the path of power?</strong></p>
         <label>
           <input type="radio" name="q8" value="a">
-          A. The path of power must turn 90 ° from the input.
+          The path of power must turn 90 ° from the input.
         </label>
         <label>
           <input type="radio" name="q8" value="b">
-          B. The path of power must be parallel to the differential case.
+          The path of power must be parallel to the differential case.
         </label>
         <label>
           <input type="radio" name="q8" value="c">
-          C. The path of power does not always turn 90 ° .
+          The path of power does not always turn 90 ° .
         </label>
         <label>
           <input type="radio" name="q8" value="d">
-          D. The output rotation must be above the centerline of the ring gear.
+          The output rotation must be above the centerline of the ring gear.
         </label>
       </div>
       <div class="question">
         <p><strong>Drive axle gear sets transfer power between two shafts whose centrelines are parallel. What is the most common type of gear used for this application, particularly in front-wheel drive vehicles?</strong></p>
         <label>
           <input type="radio" name="q9" value="a">
-          A. Hypoid gears
+          Hypoid gears
         </label>
         <label>
           <input type="radio" name="q9" value="b">
-          B. Bevel gears
+          Bevel gears
         </label>
         <label>
           <input type="radio" name="q9" value="c">
-          C. Helical gears
+          Helical gears
         </label>
         <label>
           <input type="radio" name="q9" value="d">
-          D. Bevelled spur gears
+          Bevelled spur gears
         </label>
       </div>
       <div class="question">
         <p><strong>What is the mathematical method used to calculate the gear ratio of the crown and pinion set?</strong></p>
         <label>
           <input type="radio" name="q10" value="a">
-          A. Dividing the number of teeth on the pinion by the number of teeth on the ring gear.
+          Dividing the number of teeth on the pinion by the number of teeth on the ring gear.
         </label>
         <label>
           <input type="radio" name="q10" value="b">
-          B. Multiplying the ring gear diameter by the pinion gear diameter.
+          Multiplying the ring gear diameter by the pinion gear diameter.
         </label>
         <label>
           <input type="radio" name="q10" value="c">
-          C. Dividing the number of teeth on the ring by the number of teeth on the pinion gear.
+          Dividing the number of teeth on the ring by the number of teeth on the pinion gear.
         </label>
         <label>
           <input type="radio" name="q10" value="d">
-          D. Counting the total number of gear sets in the axle assembly.
+          Counting the total number of gear sets in the axle assembly.
         </label>
       </div>
       <div class="question">
         <p><strong>Which axle type is most common in rear-wheel drive passenger vehicles and supports the weight of the vehicle while propelling the wheel?</strong></p>
         <label>
           <input type="radio" name="q11" value="a">
-          A. Full floating axle
+          Full floating axle
         </label>
         <label>
           <input type="radio" name="q11" value="b">
-          B. Independent (swing axle)
+          Independent (swing axle)
         </label>
         <label>
           <input type="radio" name="q11" value="c">
-          C. Semi-floating axle
+          Semi-floating axle
         </label>
         <label>
           <input type="radio" name="q11" value="d">
-          D. Removable carrier axle housing
+          Removable carrier axle housing
         </label>
       </div>
       <div class="question">
         <p><strong>A full floating axle is commonly found on 3/4-ton and heavier vehicles. Which function is solely performed by the axle shaft in this design?</strong></p>
         <label>
           <input type="radio" name="q12" value="a">
-          A. Supporting the vehicle weight.
+          Supporting the vehicle weight.
         </label>
         <label>
           <input type="radio" name="q12" value="b">
-          B. Transferring side thrust.
+          Transferring side thrust.
         </label>
         <label>
           <input type="radio" name="q12" value="c">
-          C. Supporting the outer end with a wheel bearing.
+          Supporting the outer end with a wheel bearing.
         </label>
         <label>
           <input type="radio" name="q12" value="d">
-          D. Transferring torque between the wheels and the driveline.
+          Transferring torque between the wheels and the driveline.
         </label>
       </div>
       <div class="question">
         <p><strong>In a semi-floating axle that uses straight roller bearings to support the axle shaft, how is the required side thrust control transferred to the axle housing?</strong></p>
         <label>
           <input type="radio" name="q13" value="a">
-          A. The outer bearing retainer plate absorbs the thrust directly.
+          The outer bearing retainer plate absorbs the thrust directly.
         </label>
         <label>
           <input type="radio" name="q13" value="b">
-          B. A C-lock on the end of each axle allows the axle shaft to press against the differential pinion shaft, which transfers thrust to the differential case side bearings.
+          A C-lock on the end of each axle allows the axle shaft to press against the differential pinion shaft, which transfers thrust to the differential case side bearings.
         </label>
         <label>
           <input type="radio" name="q13" value="c">
-          C. The inner end of the axle shaft is supported by a pilot bearing inside the differential case.
+          The inner end of the axle shaft is supported by a pilot bearing inside the differential case.
         </label>
         <label>
           <input type="radio" name="q13" value="d">
-          D. The differential side gear transfers thrust directly to the axle housing via shims.
+          The differential side gear transfers thrust directly to the axle housing via shims.
         </label>
       </div>
       <div class="question">
         <p><strong>To service an axle in an integral carrier axle housing, which procedure must be performed first?</strong></p>
         <label>
           <input type="radio" name="q14" value="a">
-          A. Remove the companion flange.
+          Remove the companion flange.
         </label>
         <label>
           <input type="radio" name="q14" value="b">
-          B. Remove the differential carrier.
+          Remove the differential carrier.
         </label>
         <label>
           <input type="radio" name="q14" value="c">
-          C. Remove the rear cover.
+          Remove the rear cover.
         </label>
         <label>
           <input type="radio" name="q14" value="d">
-          D. Remove the axle shaft locking clip.
+          Remove the axle shaft locking clip.
         </label>
       </div>
       <div class="question">
         <p><strong>What distinguishes the integral carrier axle housing from the removable carrier (banjo type) axle housing?</strong></p>
         <label>
           <input type="radio" name="q15" value="a">
-          A. The integral carrier uses steel axle tubes, while the removable carrier uses cast iron tubes.
+          The integral carrier uses steel axle tubes, while the removable carrier uses cast iron tubes.
         </label>
         <label>
           <input type="radio" name="q15" value="b">
-          B. The integral carrier has a removable cover opposite the companion flange, while the removable carrier does not have a removable cover.
+          The integral carrier has a removable cover opposite the companion flange, while the removable carrier does not have a removable cover.
         </label>
         <label>
           <input type="radio" name="q15" value="c">
-          C. The integral carrier is used on 3/4-ton and larger trucks only.
+          The integral carrier is used on 3/4-ton and larger trucks only.
         </label>
         <label>
           <input type="radio" name="q15" value="d">
-          D. The integral carrier uses coil springs, while the removable carrier uses leaf springs.
+          The integral carrier uses coil springs, while the removable carrier uses leaf springs.
         </label>
       </div>
       <div class="question">
         <p><strong>What critical adjustment is controlled by the side-to-side position of the differential case, which is set using selective shims or threaded adjusters?</strong></p>
         <label>
           <input type="radio" name="q16" value="a">
-          A. Pinion depth
+          Pinion depth
         </label>
         <label>
           <input type="radio" name="q16" value="b">
-          B. Pinion bearing preload
+          Pinion bearing preload
         </label>
         <label>
           <input type="radio" name="q16" value="c">
-          C. Backlash between the drive pinion and the ring gear.
+          Backlash between the drive pinion and the ring gear.
         </label>
         <label>
           <input type="radio" name="q16" value="d">
-          D. Differential gear ratio.
+          Differential gear ratio.
         </label>
       </div>
       <div class="question">
         <p><strong>To maintain proper preload on drive pinion tapered roller bearings, many manufacturers utilize a crush sleeve positioned between the bearings. What is the mandatory replacement rule concerning this component?</strong></p>
         <label>
           <input type="radio" name="q17" value="a">
-          A. It must be lubricated with high-viscosity gear oil upon removal.
+          It must be lubricated with high-viscosity gear oil upon removal.
         </label>
         <label>
           <input type="radio" name="q17" value="b">
-          B. It must be replaced only if it shows scoring or galling.
+          It must be replaced only if it shows scoring or galling.
         </label>
         <label>
           <input type="radio" name="q17" value="c">
-          C. Once a crush sleeve has been used, it cannot be reused.
+          Once a crush sleeve has been used, it cannot be reused.
         </label>
         <label>
           <input type="radio" name="q17" value="d">
-          D. It must be shimmed precisely to match the bearing race diameter.
+          It must be shimmed precisely to match the bearing race diameter.
         </label>
       </div>
       <div class="question">
         <p><strong>What is the fundamental requirement for bevel gears used in the differential, such as bevelled spur gears, regarding the shafts they connect?</strong></p>
         <label>
           <input type="radio" name="q18" value="a">
-          A. They must provide a very large torque multiplication.
+          They must provide a very large torque multiplication.
         </label>
         <label>
           <input type="radio" name="q18" value="b">
-          B. They must be used where the shafts are parallel.
+          They must be used where the shafts are parallel.
         </label>
         <label>
           <input type="radio" name="q18" value="c">
-          C. The gears must rotate at 90 ° to each other.
+          The gears must rotate at 90 ° to each other.
         </label>
         <label>
           <input type="radio" name="q18" value="d">
-          D. They must eliminate all end thrust.
+          They must eliminate all end thrust.
         </label>
       </div>
       <div class="question">
         <p><strong>In a standard differential, when a vehicle is driving in a straight line, what is the state of the gear rotation?</strong></p>
         <label>
           <input type="radio" name="q19" value="a">
-          A. The pinion gears rotate on their shaft to divide torque.
+          The pinion gears rotate on their shaft to divide torque.
         </label>
         <label>
           <input type="radio" name="q19" value="b">
-          B. The differential case speed is greater than the wheel speed.
+          The differential case speed is greater than the wheel speed.
         </label>
         <label>
           <input type="radio" name="q19" value="c">
-          C. Everything (ring gear, differential case, pinion gears, axle gears, and wheels) turns at the same speed.
+          Everything (ring gear, differential case, pinion gears, axle gears, and wheels) turns at the same speed.
         </label>
         <label>
           <input type="radio" name="q19" value="d">
-          D. The outside wheel rotates 110% faster than the inner wheel.
+          The outside wheel rotates 110% faster than the inner wheel.
         </label>
       </div>
       <div class="question">
         <p><strong>When a vehicle with a standard differential is rounding a corner, what occurs regarding the speed of the wheels relative to the differential case?</strong></p>
         <label>
           <input type="radio" name="q20" value="a">
-          A. The inside wheel speeds up, and the outside wheel slows down.
+          The inside wheel speeds up, and the outside wheel slows down.
         </label>
         <label>
           <input type="radio" name="q20" value="b">
-          B. The inside wheel slows down, and the outside wheel speeds up.
+          The inside wheel slows down, and the outside wheel speeds up.
         </label>
         <label>
           <input type="radio" name="q20" value="c">
-          C. Both wheels speed up to match the ring gear speed.
+          Both wheels speed up to match the ring gear speed.
         </label>
         <label>
           <input type="radio" name="q20" value="d">
-          D. The differential case speed increases to equal the average of the two wheel speeds.
+          The differential case speed increases to equal the average of the two wheel speeds.
         </label>
       </div>
       <div class="question">
         <p><strong>What component of the standard differential ensures that torque is divided equally between both drive wheels?</strong></p>
         <label>
           <input type="radio" name="q21" value="a">
-          A. The ring gear
+          The ring gear
         </label>
         <label>
           <input type="radio" name="q21" value="b">
-          B. The differential case
+          The differential case
         </label>
         <label>
           <input type="radio" name="q21" value="c">
-          C. The differential pinion gears
+          The differential pinion gears
         </label>
         <label>
           <input type="radio" name="q21" value="d">
-          D. The axle shafts
+          The axle shafts
         </label>
       </div>
       <div class="question">
         <p><strong>A standard differential always splits the torque equally between the two driving wheels. If one wheel is on a slippery surface (ice), what is the maximum torque that can be delivered to the wheel with traction?</strong></p>
         <label>
           <input type="radio" name="q22" value="a">
-          A. The torque required to overcome friction at the wheel with traction.
+          The torque required to overcome friction at the wheel with traction.
         </label>
         <label>
           <input type="radio" name="q22" value="b">
-          B. Double the torque required to overcome traction at the wheel on the ice.
+          Double the torque required to overcome traction at the wheel on the ice.
         </label>
         <label>
           <input type="radio" name="q22" value="c">
-          C. The torque required to overcome traction at the wheel on the ice.
+          The torque required to overcome traction at the wheel on the ice.
         </label>
         <label>
           <input type="radio" name="q22" value="d">
-          D. The maximum available engine torque.
+          The maximum available engine torque.
         </label>
       </div>
       <div class="question">
         <p><strong>Traction-enhancing differentials are classified into two main categories: those that limit differential action and those that eliminate differential action completely. Which category is achieved by mechanically locking the two axles together?</strong></p>
         <label>
           <input type="radio" name="q23" value="a">
-          A. Friction designs
+          Friction designs
         </label>
         <label>
           <input type="radio" name="q23" value="b">
-          B. Locking differentials
+          Locking differentials
         </label>
         <label>
           <input type="radio" name="q23" value="c">
-          C. Viscous coupling differentials
+          Viscous coupling differentials
         </label>
         <label>
           <input type="radio" name="q23" value="d">
-          D. Limited slip differentials
+          Limited slip differentials
         </label>
       </div>
       <div class="question">
         <p><strong>A differential with four differential pinion gears instead of the standard two is used to provide what specific performance characteristic?</strong></p>
         <label>
           <input type="radio" name="q24" value="a">
-          A. Better traction on slippery surfaces.
+          Better traction on slippery surfaces.
         </label>
         <label>
           <input type="radio" name="q24" value="b">
-          B. Greater torque multiplication.
+          Greater torque multiplication.
         </label>
         <label>
           <input type="radio" name="q24" value="c">
-          C. Increased load capacity by dividing the torque between four gears, reducing the load on each pinion gear.
+          Increased load capacity by dividing the torque between four gears, reducing the load on each pinion gear.
         </label>
         <label>
           <input type="radio" name="q24" value="d">
-          D. More gear reduction for high-speed operation.
+          More gear reduction for high-speed operation.
         </label>
       </div>
       <div class="question">
         <p><strong>Disc Clutch Differentials (Limited Slip, Posi-Trac, etc.) use friction plates (clutch packs) that are stacked alternately between internally splined plates (engaging the side gear) and externally splined plates (engaging the differential case). When loss of traction occurs, what happens?</strong></p>
         <label>
           <input type="radio" name="q25" value="a">
-          A. The clutch pack disengages, allowing the wheel with traction to spin.
+          The clutch pack disengages, allowing the wheel with traction to spin.
         </label>
         <label>
           <input type="radio" name="q25" value="b">
-          B. The internal splines sheer, locking the two axle gears together.
+          The internal splines sheer, locking the two axle gears together.
         </label>
         <label>
           <input type="radio" name="q25" value="c">
-          C. The clutch pack is placed under compression, causing the side gear to be driven by the case through the clutch pack in addition to the normal path of power.
+          The clutch pack is placed under compression, causing the side gear to be driven by the case through the clutch pack in addition to the normal path of power.
         </label>
         <label>
           <input type="radio" name="q25" value="d">
-          D. The pinion gears stop rotating entirely, transferring power directly to the axle.
+          The pinion gears stop rotating entirely, transferring power directly to the axle.
         </label>
       </div>
       <div class="question">
         <p><strong>In a disc clutch differential, what components supply the spring tension necessary to compress the clutch packs, thereby creating the clutch preload?</strong></p>
         <label>
           <input type="radio" name="q26" value="a">
-          A. Axial loads generated by the wheel bearings.
+          Axial loads generated by the wheel bearings.
         </label>
         <label>
           <input type="radio" name="q26" value="b">
-          B. Coil type pre-load springs, wave springs, dished plates (Belleville spring), or wave plates.
+          Coil type pre-load springs, wave springs, dished plates (Belleville spring), or wave plates.
         </label>
         <label>
           <input type="radio" name="q26" value="c">
-          C. The friction discs and steel plates themselves.
+          The friction discs and steel plates themselves.
         </label>
         <label>
           <input type="radio" name="q26" value="d">
-          D. The torque required to slip the clutches.
+          The torque required to slip the clutches.
         </label>
       </div>
       <div class="question">
         <p><strong>Traction-enhancing differentials utilize the natural tendency of bevelled spur gears to thrust one another apart under load. This thrust is transferred to the axle side gear and used to provide what function?</strong></p>
         <label>
           <input type="radio" name="q27" value="a">
-          A. Additional compression on the clutch packs behind the axle gears.
+          Additional compression on the clutch packs behind the axle gears.
         </label>
         <label>
           <input type="radio" name="q27" value="b">
-          B. Torsional dampening to prevent wheel hop.
+          Torsional dampening to prevent wheel hop.
         </label>
         <label>
           <input type="radio" name="q27" value="c">
-          C. Lubrication spaces between the shaft and the pinion gears.
+          Lubrication spaces between the shaft and the pinion gears.
         </label>
         <label>
           <input type="radio" name="q27" value="d">
-          D. Constant velocity when operating at high angles.
+          Constant velocity when operating at high angles.
         </label>
       </div>
       <div class="question">
         <p><strong>The multi-disc limited slip differential does not permanently lock the differential case and axle side gears. What condition allows normal differential action (slippage) to occur when turning a corner?</strong></p>
         <label>
           <input type="radio" name="q28" value="a">
-          A. The pinion gears stop rotating on their shaft.
+          The pinion gears stop rotating on their shaft.
         </label>
         <label>
           <input type="radio" name="q28" value="b">
-          B. The spring tension exerted by the pre-load springs can be overcome.
+          The spring tension exerted by the pre-load springs can be overcome.
         </label>
         <label>
           <input type="radio" name="q28" value="c">
-          C. The differential governor activates the locking feature.
+          The differential governor activates the locking feature.
         </label>
         <label>
           <input type="radio" name="q28" value="d">
-          D. The side thrust is eliminated by the thrust washers.
+          The side thrust is eliminated by the thrust washers.
         </label>
       </div>
       <div class="question">
         <p><strong>If a vehicle is equipped with a limited slip differential (LSD) assembly, what maintenance additive is generally required and may be contained in a special lubricant or supplied separately?</strong></p>
         <label>
           <input type="radio" name="q29" value="a">
-          A. Extreme-pressure (EP) additive.
+          Extreme-pressure (EP) additive.
         </label>
         <label>
           <input type="radio" name="q29" value="b">
-          B. Anti-foaming agent.
+          Anti-foaming agent.
         </label>
         <label>
           <input type="radio" name="q29" value="c">
-          C. Friction modifier.
+          Friction modifier.
         </label>
         <label>
           <input type="radio" name="q29" value="d">
-          D. Seal compatibility additive.
+          Seal compatibility additive.
         </label>
       </div>
       <div class="question">
         <p><strong>Cone Clutch Differentials operate on the same principle as disc clutch types, but instead use cone clutches placed between the side gears and the differential case. What feature on the cone’s machined surface is designed to cut through the lubrication film and bite into the differential case?</strong></p>
         <label>
           <input type="radio" name="q30" value="a">
-          A. Axial splines
+          Axial splines
         </label>
         <label>
           <input type="radio" name="q30" value="b">
-          B. Internal threads
+          Internal threads
         </label>
         <label>
           <input type="radio" name="q30" value="c">
-          C. A spiral groove or milled slots.
+          A spiral groove or milled slots.
         </label>
         <label>
           <input type="radio" name="q30" value="d">
-          D. A smooth, heat-treated surface.
+          A smooth, heat-treated surface.
         </label>
       </div>
       <div class="question">
         <p><strong>In a Viscous Coupling Differential (popular in AWD and SUV applications), torque transfer occurs due to the use of viscous silicone oil and multiple perforated plates. What property of the silicone oil causes it to become more adhesive and resistant to flow?</strong></p>
         <label>
           <input type="radio" name="q31" value="a">
-          A. High oxidation resistance.
+          High oxidation resistance.
         </label>
         <label>
           <input type="radio" name="q31" value="b">
-          B. It is heated through agitation (shearing).
+          It is heated through agitation (shearing).
         </label>
         <label>
           <input type="radio" name="q31" value="c">
-          C. Low temperature mobility.
+          Low temperature mobility.
         </label>
         <label>
           <input type="radio" name="q31" value="d">
-          D. Resistance to foaming.
+          Resistance to foaming.
         </label>
       </div>
       <div class="question">
         <p><strong>The Eaton Locking Clutch Differential is distinct because there is almost no discernible drag until the locking feature is activated by what mechanism?</strong></p>
         <label>
           <input type="radio" name="q32" value="a">
-          A. The friction discs slipping excessively.
+          The friction discs slipping excessively.
         </label>
         <label>
           <input type="radio" name="q32" value="b">
-          B. The governor engages.
+          The governor engages.
         </label>
         <label>
           <input type="radio" name="q32" value="c">
-          C. The operator twists one axle shaft in the opposite direction.
+          The operator twists one axle shaft in the opposite direction.
         </label>
         <label>
           <input type="radio" name="q32" value="d">
-          D. The air shift cylinder is actuated.
+          The air shift cylinder is actuated.
         </label>
       </div>
       <div class="question">
         <p><strong>How does a technician typically confirm that a differential is a traction-enhancing type (rather than a standard differential) without dismantling it?</strong></p>
         <label>
           <input type="radio" name="q33" value="a">
-          A. Drive the vehicle slowly around a corner and listen for gear clash.
+          Drive the vehicle slowly around a corner and listen for gear clash.
         </label>
         <label>
           <input type="radio" name="q33" value="b">
-          B. Raise the vehicle, put the transmission in neutral, and if turning one wheel causes the opposite wheel to turn in the same direction, it is safe to assume it is traction-enhancing.
+          Raise the vehicle, put the transmission in neutral, and if turning one wheel causes the opposite wheel to turn in the same direction, it is safe to assume it is traction-enhancing.
         </label>
         <label>
           <input type="radio" name="q33" value="c">
-          C. Check for excessive backlash between the ring and pinion.
+          Check for excessive backlash between the ring and pinion.
         </label>
         <label>
           <input type="radio" name="q33" value="d">
-          D. Measure the side thrust tolerance on the axle shaft.
+          Measure the side thrust tolerance on the axle shaft.
         </label>
       </div>
       <div class="question">
         <p><strong>Locking differentials eliminate differential action completely by mechanically locking the two axles together. When is this locking action typically initiated in an Eaton Locker type differential?</strong></p>
         <label>
           <input type="radio" name="q34" value="a">
-          A. Immediately when the clutch is disengaged.
+          Immediately when the clutch is disengaged.
         </label>
         <label>
           <input type="radio" name="q34" value="b">
-          B. When the operator sharply twists one axle shaft in either direction, causing the governor to engage with a solid clunk.
+          When the operator sharply twists one axle shaft in either direction, causing the governor to engage with a solid clunk.
         </label>
         <label>
           <input type="radio" name="q34" value="c">
-          C. When the vehicle is placed into deep reduction gear.
+          When the vehicle is placed into deep reduction gear.
         </label>
         <label>
           <input type="radio" name="q34" value="d">
-          D. When the temperature of the gear oil exceeds 90 ° C.
+          When the temperature of the gear oil exceeds 90 ° C.
         </label>
       </div>
       <div class="question">
         <p><strong>The term preload (in the context of tapered roller bearings) is defined as the pressure required to make the bearing and the race contact each other, causing the rollers to rotate. What is the explicit purpose of this preload?</strong></p>
         <label>
           <input type="radio" name="q35" value="a">
-          A. To lubricate the bearing surfaces.
+          To lubricate the bearing surfaces.
         </label>
         <label>
           <input type="radio" name="q35" value="b">
-          B. To prevent any axial movement.
+          To prevent any axial movement.
         </label>
         <label>
           <input type="radio" name="q35" value="c">
-          C. To increase the gear ratio.
+          To increase the gear ratio.
         </label>
         <label>
           <input type="radio" name="q35" value="d">
-          D. To reduce the need for thrust washers.
+          To reduce the need for thrust washers.
         </label>
       </div>
       <div class="question">
         <p><strong>What is the classification of gear oil that is recommended for use with hypoid gear sets?</strong></p>
         <label>
           <input type="radio" name="q36" value="a">
-          A. SAE 75W
+          SAE 75W
         </label>
         <label>
           <input type="radio" name="q36" value="b">
-          B. GL-1
+          GL-1
         </label>
         <label>
           <input type="radio" name="q36" value="c">
-          C. API GL-5
+          API GL-5
         </label>
         <label>
           <input type="radio" name="q36" value="d">
-          D. SAE 140
+          SAE 140
         </label>
       </div>
       <div class="question">
         <p><strong>What is the specific role of an extreme-pressure (EP) additive like zinc dithiophosphate in drive axle gear oil?</strong></p>
         <label>
           <input type="radio" name="q37" value="a">
-          A. To minimize foaming during high-speed rotation.
+          To minimize foaming during high-speed rotation.
         </label>
         <label>
           <input type="radio" name="q37" value="b">
-          B. To maintain viscosity over a wide temperature range.
+          To maintain viscosity over a wide temperature range.
         </label>
         <label>
           <input type="radio" name="q37" value="c">
-          C. To adhere to gear surfaces and prevent metal-to-metal contact under high torque conditions.
+          To adhere to gear surfaces and prevent metal-to-metal contact under high torque conditions.
         </label>
         <label>
           <input type="radio" name="q37" value="d">
-          D. To improve oil flow when the differential is cold.
+          To improve oil flow when the differential is cold.
         </label>
       </div>
       <div class="question">
         <p><strong>Which of the following is a potential consequence if the drive axle breather vent is not kept unrestricted?</strong></p>
         <label>
           <input type="radio" name="q38" value="a">
-          A. Gear oil viscosity will break down rapidly.
+          Gear oil viscosity will break down rapidly.
         </label>
         <label>
           <input type="radio" name="q38" value="b">
-          B. The clutch preload will increase.
+          The clutch preload will increase.
         </label>
         <label>
           <input type="radio" name="q38" value="c">
-          C. Fluid leaks from any of the axle housing seals (due to excess pressure).
+          Fluid leaks from any of the axle housing seals (due to excess pressure).
         </label>
         <label>
           <input type="radio" name="q38" value="d">
-          D. The driveshaft will speed up and slow down (variable velocity).
+          The driveshaft will speed up and slow down (variable velocity).
         </label>
       </div>
       <div class="question">
         <p><strong>Drive axle gear oil must be checked against the manufacturer&#x27;s specifications for two major classifications: SAE (viscosity) and API (application). Why must a customer always check manufacturer specifications before adding any fluid?</strong></p>
         <label>
           <input type="radio" name="q39" value="a">
-          A. To ensure the fluid can resist mechanical linkage wear.
+          To ensure the fluid can resist mechanical linkage wear.
         </label>
         <label>
           <input type="radio" name="q39" value="b">
-          B. To ensure the fluid has a high enough GL number for all applications.
+          To ensure the fluid has a high enough GL number for all applications.
         </label>
         <label>
           <input type="radio" name="q39" value="c">
-          C. Mixing different types of gear oil causes a breakdown chemically.
+          Mixing different types of gear oil causes a breakdown chemically.
         </label>
         <label>
           <input type="radio" name="q39" value="d">
-          D. To confirm the axle housing has a dedicated oil pump.
+          To confirm the axle housing has a dedicated oil pump.
         </label>
       </div>
       <div class="question">
         <p><strong>How does the splash lubrication system commonly used in remote axle assemblies ensure internal components are lubricated?</strong></p>
         <label>
           <input type="radio" name="q40" value="a">
-          A. The transaxle dipstick checks the oil level in the common sump.
+          The transaxle dipstick checks the oil level in the common sump.
         </label>
         <label>
           <input type="radio" name="q40" value="b">
-          B. The ring gear and differential case turn, drawing oil out of the sump and throwing it up and forward against the top of the axle housing.
+          The ring gear and differential case turn, drawing oil out of the sump and throwing it up and forward against the top of the axle housing.
         </label>
         <label>
           <input type="radio" name="q40" value="c">
-          C. Helical gears transfer oil between two shafts with parallel centrelines.
+          Helical gears transfer oil between two shafts with parallel centrelines.
         </label>
         <label>
           <input type="radio" name="q40" value="d">
-          D. A dedicated low-pressure pump directs oil through channels in the case.
+          A dedicated low-pressure pump directs oil through channels in the case.
         </label>
       </div>
       <div class="question">
         <p><strong>In a transversely mounted transaxle using helical drive axle gears, how do the demands on the lubricating oil compare to those of a rear axle assembly using hypoid gear sets?</strong></p>
         <label>
           <input type="radio" name="q41" value="a">
-          A. The demands on the oil are equally high due to axial thrust.
+          The demands on the oil are equally high due to axial thrust.
         </label>
         <label>
           <input type="radio" name="q41" value="b">
-          B. The demands on the oil are not as high.
+          The demands on the oil are not as high.
         </label>
         <label>
           <input type="radio" name="q41" value="c">
-          C. Helical gear sets always require ATF fluid, which has higher demands.
+          Helical gear sets always require ATF fluid, which has higher demands.
         </label>
         <label>
           <input type="radio" name="q41" value="d">
-          D. Transaxles require a high GL number gear oil.
+          Transaxles require a high GL number gear oil.
         </label>
       </div>
       <div class="question">
         <p><strong>What is the primary method for identifying the specific drive axle assembly when providing replacement crown and pinions?</strong></p>
         <label>
           <input type="radio" name="q42" value="a">
-          A. Matching the ratio (e.g., 3.50) stamped on the axle tube.
+          Matching the ratio (e.g., 3.50) stamped on the axle tube.
         </label>
         <label>
           <input type="radio" name="q42" value="b">
-          B. Measuring the diameter of the crown gear.
+          Measuring the diameter of the crown gear.
         </label>
         <label>
           <input type="radio" name="q42" value="c">
-          C. Decoding the axle assembly identification number (stamping codes or metal tag).
+          Decoding the axle assembly identification number (stamping codes or metal tag).
         </label>
         <label>
           <input type="radio" name="q42" value="d">
-          D. Identifying the type of carrier (integral or removable).
+          Identifying the type of carrier (integral or removable).
         </label>
       </div>
       <div class="question">
         <p><strong>Axle shafts are manufactured with splines machined at the inner end. What is the purpose of these splines?</strong></p>
         <label>
           <input type="radio" name="q43" value="a">
-          A. To accommodate C-locks for side thrust control.
+          To accommodate C-locks for side thrust control.
         </label>
         <label>
           <input type="radio" name="q43" value="b">
-          B. To allow the shaft to be pressed onto a retainer ring.
+          To allow the shaft to be pressed onto a retainer ring.
         </label>
         <label>
           <input type="radio" name="q43" value="c">
-          C. To engage the differential side gears for power transmission to the wheels.
+          To engage the differential side gears for power transmission to the wheels.
         </label>
         <label>
           <input type="radio" name="q43" value="d">
-          D. To support the vehicle weight (radial loads).
+          To support the vehicle weight (radial loads).
         </label>
       </div>
       <div class="question">
         <p><strong>Axial loads are defined as loads that run parallel to the centerline of the shaft. Which type of bearing is normally used in most drive axle applications because it can accept and control both radial and axial loads?</strong></p>
         <label>
           <input type="radio" name="q44" value="a">
-          A. Straight roller bearings
+          Straight roller bearings
         </label>
         <label>
           <input type="radio" name="q44" value="b">
-          B. Ball bearings
+          Ball bearings
         </label>
         <label>
           <input type="radio" name="q44" value="c">
-          C. Tapered roller bearings
+          Tapered roller bearings
         </label>
         <label>
           <input type="radio" name="q44" value="d">
-          D. Spherical roller bearings
+          Spherical roller bearings
         </label>
       </div>
       <div class="question">
         <p><strong>When a differential is subjected to the spinning of one wheel (such as when stuck), severe wear can occur to the differential pinion gears. This is because:</strong></p>
         <label>
           <input type="radio" name="q45" value="a">
-          A. They are made of bevelled spur gears, a relatively weak set.
+          They are made of bevelled spur gears, a relatively weak set.
         </label>
         <label>
           <input type="radio" name="q45" value="b">
-          B. Under normal driving conditions, they do not turn at high speed on the differential pinion shaft, but high-speed turning occurs when one wheel spins.
+          Under normal driving conditions, they do not turn at high speed on the differential pinion shaft, but high-speed turning occurs when one wheel spins.
         </label>
         <label>
           <input type="radio" name="q45" value="c">
-          C. They are always preloaded with heavy springs, increasing friction.
+          They are always preloaded with heavy springs, increasing friction.
         </label>
         <label>
           <input type="radio" name="q45" value="d">
-          D. They are locked to the differential case via the side gear thrust washers.
+          They are locked to the differential case via the side gear thrust washers.
         </label>
       </div>
       <div class="question">
         <p><strong>When a pinion seal (#41) fails, which common related sales items should a parts technician suggest to the customer (Table 2)?</strong></p>
         <label>
           <input type="radio" name="q46" value="a">
-          A. Companion flange/yoke, crush sleeve, and gear lube.
+          Companion flange/yoke, crush sleeve, and gear lube.
         </label>
         <label>
           <input type="radio" name="q46" value="b">
-          B. Crown and pinion set, shims, and gaskets.
+          Crown and pinion set, shims, and gaskets.
         </label>
         <label>
           <input type="radio" name="q46" value="c">
-          C. Differential case and differential gears.
+          Differential case and differential gears.
         </label>
         <label>
           <input type="radio" name="q46" value="d">
-          D. Thrust washers and rear axle housing.
+          Thrust washers and rear axle housing.
         </label>
       </div>
       <div class="question">
         <p><strong>When a differential case fails, what essential components are suggested as related sales, according to Table 2?</strong></p>
         <label>
           <input type="radio" name="q47" value="a">
-          A. Bearings, gasket and seals, differential cross-shaft, differential gears, shims, crush sleeve, gasket, and gear lube.
+          Bearings, gasket and seals, differential cross-shaft, differential gears, shims, crush sleeve, gasket, and gear lube.
         </label>
         <label>
           <input type="radio" name="q47" value="b">
-          B. Only the crown and pinion set.
+          Only the crown and pinion set.
         </label>
         <label>
           <input type="radio" name="q47" value="c">
-          C. Only the axle tube vent and hose.
+          Only the axle tube vent and hose.
         </label>
         <label>
           <input type="radio" name="q47" value="d">
-          D. Side gears and axle shaft flanges.
+          Side gears and axle shaft flanges.
         </label>
       </div>
       <div class="question">
         <p><strong>When a semi-floating axle uses a ball bearing type for support, how are the side thrust forces transferred from the axle to the axle housing?</strong></p>
         <label>
           <input type="radio" name="q48" value="a">
-          A. Via the C-lock and differential pinion shaft.
+          Via the C-lock and differential pinion shaft.
         </label>
         <label>
           <input type="radio" name="q48" value="b">
-          B. By the inner axle seal and thrust washer.
+          By the inner axle seal and thrust washer.
         </label>
         <label>
           <input type="radio" name="q48" value="c">
-          C. Through the bearing and the retainer plate located at the outer end of the axle housing.
+          Through the bearing and the retainer plate located at the outer end of the axle housing.
         </label>
         <label>
           <input type="radio" name="q48" value="d">
-          D. By the wheel hub assembly.
+          By the wheel hub assembly.
         </label>
       </div>
       <div class="question">
         <p><strong>What is the purpose of the flats usually milled onto the bearing surface of the differential pinion shaft?</strong></p>
         <label>
           <input type="radio" name="q49" value="a">
-          A. To allow the shaft to be secured by a threaded pin.
+          To allow the shaft to be secured by a threaded pin.
         </label>
         <label>
           <input type="radio" name="q49" value="b">
-          B. To provide recesses for the axle shaft locking clip.
+          To provide recesses for the axle shaft locking clip.
         </label>
         <label>
           <input type="radio" name="q49" value="c">
-          C. To provide lubrication spaces between the shaft and the pinion gears.
+          To provide lubrication spaces between the shaft and the pinion gears.
         </label>
         <label>
           <input type="radio" name="q49" value="d">
-          D. To hold the thrust washers in place axially.
+          To hold the thrust washers in place axially.
         </label>
       </div>
       <div class="question">
         <p><strong>Based on the identification tag example (Figure 11), a ratio stamped as 3L00 indicates what specific design feature of the axle assembly?</strong></p>
         <label>
           <input type="radio" name="q50" value="a">
-          A. A removable carrier housing
+          A removable carrier housing
         </label>
         <label>
           <input type="radio" name="q50" value="b">
-          B. A fixed yoke (companion flange)
+          A fixed yoke (companion flange)
         </label>
         <label>
           <input type="radio" name="q50" value="c">
-          C. A Traction-Lok (Limited Slip)
+          A Traction-Lok (Limited Slip)
         </label>
         <label>
           <input type="radio" name="q50" value="d">
-          D. A straight roller bearing type --------------------------------------------------------------------------------
+          A straight roller bearing type --------------------------------------------------------------------------------
         </label>
       </div>
 

--- a/270202-test/270202h - Heavy-Duty Drive Axle Assemblies.html
+++ b/270202-test/270202h - Heavy-Duty Drive Axle Assemblies.html
@@ -71,402 +71,402 @@
 
  <div class="question">
             <p><strong>A tandem drive axle model is designated as DS404-P. Using the identification codes, what is the nominal Gross Axle Weight Rating (GAWR) per tandem in pounds?</strong></p>
-            <label><input type="radio" name="q1" value="a"> A. 4,000 pounds</label>
-            <label><input type="radio" name="q1" value="b"> B. 10,000 pounds</label>
-            <label><input type="radio" name="q1" value="c"> C. 40,000 pounds</label>
-            <label><input type="radio" name="q1" value="d"> D. 400,000 pounds</label>
+            <label><input type="radio" name="q1" value="a">4,000 pounds</label>
+            <label><input type="radio" name="q1" value="b">10,000 pounds</label>
+            <label><input type="radio" name="q1" value="c">40,000 pounds</label>
+            <label><input type="radio" name="q1" value="d">400,000 pounds</label>
         </div>
 
         <div class="question">
             <p><strong>A carrier assembly has two gear reductions. The first reduction ratio (input pinion to bevel gear) is 2.5:1, and the second reduction ratio (helical pinion to helical driven gear) is 2.0:1. What is the overall gear ratio through this carrier assembly?</strong></p>
-            <label><input type="radio" name="q2" value="a"> A. 0.5:1</label>
-            <label><input type="radio" name="q2" value="b"> B. 2.5:1</label>
-            <label><input type="radio" name="q2" value="c"> C. 5.0:1</label>
-            <label><input type="radio" name="q2" value="d"> D. 4.5:1</label>
+            <label><input type="radio" name="q2" value="a">0.5:1</label>
+            <label><input type="radio" name="q2" value="b">2.5:1</label>
+            <label><input type="radio" name="q2" value="c">5.0:1</label>
+            <label><input type="radio" name="q2" value="d">4.5:1</label>
         </div>
 
         <div class="question">
             <p><strong>In a standard differential under good traction conditions, the total torque received by the differential case assembly is 4067.4 Nm (3000 lb-ft). If the torque is divided equally, how much torque is sent to each axle shaft?</strong></p>
-            <label><input type="radio" name="q3" value="a"> A. 1016.85 Nm (750 lb-ft)</label>
-            <label><input type="radio" name="q3" value="b"> B. 1355.8 Nm (1000 lb-ft)</label>
-            <label><input type="radio" name="q3" value="c"> C. 2033.7 Nm (1500 lb-ft)</label>
-            <label><input type="radio" name="q3" value="d"> D. 4067.4 Nm (3000 lb-ft)</label>
+            <label><input type="radio" name="q3" value="a">1016.85 Nm (750 lb-ft)</label>
+            <label><input type="radio" name="q3" value="b">1355.8 Nm (1000 lb-ft)</label>
+            <label><input type="radio" name="q3" value="c">2033.7 Nm (1500 lb-ft)</label>
+            <label><input type="radio" name="q3" value="d">4067.4 Nm (3000 lb-ft)</label>
         </div>
 
         <div class="question">
             <p><strong>A planetary two-speed drive axle assembly has a crown gear set ratio of 3.5:1 and a planetary gear set ratio of 1.5:1 (Double Reduction in Low). What is the overall gear ratio when the assembly is operating in Low Speed?</strong></p>
-            <label><input type="radio" name="q4" value="a"> A. 2.33:1</label>
-            <label><input type="radio" name="q4" value="b"> B. 3.5:1</label>
-            <label><input type="radio" name="q4" value="c"> C. 5.0:1</label>
-            <label><input type="radio" name="q4" value="d"> D. 5.25:1</label>
+            <label><input type="radio" name="q4" value="a">2.33:1</label>
+            <label><input type="radio" name="q4" value="b">3.5:1</label>
+            <label><input type="radio" name="q4" value="c">5.0:1</label>
+            <label><input type="radio" name="q4" value="d">5.25:1</label>
         </div>
 
         <div class="question">
             <p><strong>A drive axle assembly has a crown gear with 48 teeth and a drive pinion with 10 teeth. What is the final drive gear ratio?</strong></p>
-            <label><input type="radio" name="q5" value="a"> A. 0.20:1</label>
-            <label><input type="radio" name="q5" value="b"> B. 4.00:1</label>
-            <label><input type="radio" name="q5" value="c"> C. 4.80:1</label>
-            <label><input type="radio" name="q5" value="d"> D. 5.80:1</label>
+            <label><input type="radio" name="q5" value="a">0.20:1</label>
+            <label><input type="radio" name="q5" value="b">4.00:1</label>
+            <label><input type="radio" name="q5" value="c">4.80:1</label>
+            <label><input type="radio" name="q5" value="d">5.80:1</label>
         </div>
 
         <div class="question">
             <p><strong>A drive axle assembly has a crown gear with 39 teeth and a drive pinion with 11 teeth. What is the final drive gear ratio? Round to two decimal places.</strong></p>
-            <label><input type="radio" name="q6" value="a"> A. 3.55:1</label>
-            <label><input type="radio" name="q6" value="b"> B. 3.73:1</label>
-            <label><input type="radio" name="q6" value="c"> C. 3.91:1</label>
-            <label><input type="radio" name="q6" value="d"> D. 4.10:1</label>
+            <label><input type="radio" name="q6" value="a">3.55:1</label>
+            <label><input type="radio" name="q6" value="b">3.73:1</label>
+            <label><input type="radio" name="q6" value="c">3.91:1</label>
+            <label><input type="radio" name="q6" value="d">4.10:1</label>
         </div>
 
         <div class="question">
             <p><strong>In a differential wheel spin condition, the crown gear is turning at 100 rpm and the axle shaft on one side is stopped (0 rpm). According to the differential action principle, what speed must the opposite axle wheel turn?</strong></p>
-            <label><input type="radio" name="q7" value="a"> A. 50 rpm</label>
-            <label><input type="radio" name="q7" value="b"> B. 100 rpm</label>
-            <label><input type="radio" name="q7" value="c"> C. 200 rpm</label>
-            <label><input type="radio" name="q7" value="d"> D. 300 rpm</label>
+            <label><input type="radio" name="q7" value="a">50 rpm</label>
+            <label><input type="radio" name="q7" value="b">100 rpm</label>
+            <label><input type="radio" name="q7" value="c">200 rpm</label>
+            <label><input type="radio" name="q7" value="d">300 rpm</label>
         </div>
 
         <div class="question">
             <p><strong>In an inter-axle differential spin-out condition, the forward drive axle pinion is stationary. If the inter-axle differential cross shaft is rotating at 500 rpm, what speed would the rearward drive axle pinion be spinning due to differential action?</strong></p>
-            <label><input type="radio" name="q8" value="a"> A. 500 rpm</label>
-            <label><input type="radio" name="q8" value="b"> B. 750 rpm</label>
-            <label><input type="radio" name="q8" value="c"> C. 1000 rpm</label>
-            <label><input type="radio" name="q8" value="d"> D. 250 rpm</label>
+            <label><input type="radio" name="q8" value="a">500 rpm</label>
+            <label><input type="radio" name="q8" value="b">750 rpm</label>
+            <label><input type="radio" name="q8" value="c">1000 rpm</label>
+            <label><input type="radio" name="q8" value="d">250 rpm</label>
         </div>
 
         <div class="question">
             <p><strong>Which gear arrangement term describes a drive pinion that meshes with its crown (bevel) gear above the centerline of the crown gear?</strong></p>
-            <label><input type="radio" name="q9" value="a"> A. Hypoid</label>
-            <label><input type="radio" name="q9" value="b"> B. Straddle mount</label>
-            <label><input type="radio" name="q9" value="c"> C. Amboid</label>
-            <label><input type="radio" name="q9" value="d"> D. Spiral bevel</label>
+            <label><input type="radio" name="q9" value="a">Hypoid</label>
+            <label><input type="radio" name="q9" value="b">Straddle mount</label>
+            <label><input type="radio" name="q9" value="c">Amboid</label>
+            <label><input type="radio" name="q9" value="d">Spiral bevel</label>
         </div>
 
         <div class="question">
             <p><strong>A straddle mount pinion design, which is characterized by a pilot bearing surface extending past the end of the pinion gear, is more common on applications that experience:</strong></p>
-            <label><input type="radio" name="q10" value="a"> A. Low revolutions per minute (rpm) rates.</label>
-            <label><input type="radio" name="q10" value="b"> B. High torque loads.</label>
-            <label><input type="radio" name="q10" value="c"> C. Single-speed single reduction.</label>
-            <label><input type="radio" name="q10" value="d"> D. Tridem axle arrangements.</label>
+            <label><input type="radio" name="q10" value="a">Low revolutions per minute (rpm) rates.</label>
+            <label><input type="radio" name="q10" value="b">High torque loads.</label>
+            <label><input type="radio" name="q10" value="c">Single-speed single reduction.</label>
+            <label><input type="radio" name="q10" value="d">Tridem axle arrangements.</label>
         </div>
 
         <div class="question">
             <p><strong>What is the fundamental requirement when replacing a drive pinion and crown gear set?</strong></p>
-            <label><input type="radio" name="q11" value="a"> A. They must be individually balanced and installed with new thrust washers.</label>
-            <label><input type="radio" name="q11" value="b"> B. The pinion depth must be adjusted using the pinion bearing preload spacer.</label>
-            <label><input type="radio" name="q11" value="c"> C. They must be used in matched sets as they are designed together.</label>
-            <label><input type="radio" name="q11" value="d"> D. They must utilize the largest possible diameter crown gear.</label>
+            <label><input type="radio" name="q11" value="a">They must be individually balanced and installed with new thrust washers.</label>
+            <label><input type="radio" name="q11" value="b">The pinion depth must be adjusted using the pinion bearing preload spacer.</label>
+            <label><input type="radio" name="q11" value="c">They must be used in matched sets as they are designed together.</label>
+            <label><input type="radio" name="q11" value="d">They must utilize the largest possible diameter crown gear.</label>
         </div>
 
         <div class="question">
             <p><strong>The Gross Axle Weight Rating (GAWR) is the manufacturer's rating that dictates the construction of the housing, bearings, and wheel ends based on the weight the axle must:</strong></p>
-            <label><input type="radio" name="q12" value="a"> A. Propel (Torque transfer).</label>
-            <label><input type="radio" name="q12" value="b"> B. Safely carry (Load support).</label>
-            <label><input type="radio" name="q12" value="c"> C. Transfer during a full-floating configuration.</label>
-            <label><input type="radio" name="q12" value="d"> D. Maintain in a low-speed ratio.</label>
+            <label><input type="radio" name="q12" value="a">Propel (Torque transfer).</label>
+            <label><input type="radio" name="q12" value="b">Safely carry (Load support).</label>
+            <label><input type="radio" name="q12" value="c">Transfer during a full-floating configuration.</label>
+            <label><input type="radio" name="q12" value="d">Maintain in a low-speed ratio.</label>
         </div>
 
         <div class="question">
             <p><strong>When all of the individual Gross Axle Weight Ratings (GAWR) for a vehicle are added together, they establish the total weight of the vehicle and its load, which is known as the:</strong></p>
-            <label><input type="radio" name="q13" value="a"> A. Tare Weight.</label>
-            <label><input type="radio" name="q13" value="b"> B. Gross Combination Weight Rating (GCWR).</label>
-            <label><input type="radio" name="q13" value="c"> C. Gross Vehicle Weight Rating (GVWR).</label>
-            <label><input type="radio" name="q13" value="d"> D. Axle Speed Sensing Rating (ASSR).</label>
+            <label><input type="radio" name="q13" value="a">Tare Weight.</label>
+            <label><input type="radio" name="q13" value="b">Gross Combination Weight Rating (GCWR).</label>
+            <label><input type="radio" name="q13" value="c">Gross Vehicle Weight Rating (GVWR).</label>
+            <label><input type="radio" name="q13" value="d">Axle Speed Sensing Rating (ASSR).</label>
         </div>
 
         <div class="question">
             <p><strong>What is the primary functional difference between a live axle and a dead axle?</strong></p>
-            <label><input type="radio" name="q14" value="a"> A. A live axle is found on tandem arrangements; a dead axle is found on tridem arrangements.</label>
-            <label><input type="radio" name="q14" value="b"> B. A live axle propels the vehicle; a dead axle strictly carries the load.</label>
-            <label><input type="radio" name="q14" value="c"> C. A live axle always uses a planetary two-speed carrier; a dead axle uses a single-speed reduction.</label>
-            <label><input type="radio" name="q14" value="d"> D. A live axle uses semi-floating shafts; a dead axle uses full-floating shafts.</label>
+            <label><input type="radio" name="q14" value="a">A live axle is found on tandem arrangements; a dead axle is found on tridem arrangements.</label>
+            <label><input type="radio" name="q14" value="b">A live axle propels the vehicle; a dead axle strictly carries the load.</label>
+            <label><input type="radio" name="q14" value="c">A live axle always uses a planetary two-speed carrier; a dead axle uses a single-speed reduction.</label>
+            <label><input type="radio" name="q14" value="d">A live axle uses semi-floating shafts; a dead axle uses full-floating shafts.</label>
         </div>
 
         <div class="question">
             <p><strong>What is the critical action that must occur to remove a semi-floating axle shaft from a vehicle, compared to a full-floating axle shaft?</strong></p>
-            <label><input type="radio" name="q15" value="a"> A. The axle must be locked by the differential lock.</label>
-            <label><input type="radio" name="q15" value="b"> B. The rear cover must be removed first.</label>
-            <label><input type="radio" name="q15" value="c"> C. A drive wheel must be raised off the ground before a semi-floating axle shaft can be removed.</label>
-            <label><input type="radio" name="q15" value="d"> D. The gear oil must be drained from the axle housing.</label>
+            <label><input type="radio" name="q15" value="a">The axle must be locked by the differential lock.</label>
+            <label><input type="radio" name="q15" value="b">The rear cover must be removed first.</label>
+            <label><input type="radio" name="q15" value="c">A drive wheel must be raised off the ground before a semi-floating axle shaft can be removed.</label>
+            <label><input type="radio" name="q15" value="d">The gear oil must be drained from the axle housing.</label>
         </div>
 
         <div class="question">
             <p><strong>What is the main function of the full-floating axle shaft?</strong></p>
-            <label><input type="radio" name="q16" value="a"> A. To carry the weight of the vehicle and cargo.</label>
-            <label><input type="radio" name="q16" value="b"> B. To transmit braking and cornering forces.</label>
-            <label><input type="radio" name="q16" value="c"> C. To drive the wheel and hub assembly.</label>
-            <label><input type="radio" name="q16" value="d"> D. To support the drive axle housing.</label>
+            <label><input type="radio" name="q16" value="a">To carry the weight of the vehicle and cargo.</label>
+            <label><input type="radio" name="q16" value="b">To transmit braking and cornering forces.</label>
+            <label><input type="radio" name="q16" value="c">To drive the wheel and hub assembly.</label>
+            <label><input type="radio" name="q16" value="d">To support the drive axle housing.</label>
         </div>
 
         <div class="question">
             <p><strong>If a heavy-duty truck has a tandem or tridem drive axle arrangement, what component must be added to transmit power from one drive axle to the next?</strong></p>
-            <label><input type="radio" name="q17" value="a"> A. A planetary two-speed axle assembly.</label>
-            <label><input type="radio" name="q17" value="b"> B. A speed sensing unit.</label>
-            <label><input type="radio" name="q17" value="c"> C. An inter-axle differential assembly.</label>
-            <label><input type="radio" name="q17" value="d"> D. A standard differential case.</label>
+            <label><input type="radio" name="q17" value="a">A planetary two-speed axle assembly.</label>
+            <label><input type="radio" name="q17" value="b">A speed sensing unit.</label>
+            <label><input type="radio" name="q17" value="c">An inter-axle differential assembly.</label>
+            <label><input type="radio" name="q17" value="d">A standard differential case.</label>
         </div>
 
         <div class="question">
             <p><strong>What is the primary characteristic of a single-speed single reduction carrier assembly?</strong></p>
-            <label><input type="radio" name="q18" value="a"> A. It provides two separate gear reductions.</label>
-            <label><input type="radio" name="q18" value="b"> B. It uses helical gears for the final reduction.</label>
-            <label><input type="radio" name="q18" value="c"> C. It offers only one path-of-power and one gear reduction through the drive pinion and crown gear.</label>
-            <label><input type="radio" name="q18" value="d"> D. It uses an outboard planetary final drive.</label>
+            <label><input type="radio" name="q18" value="a">It provides two separate gear reductions.</label>
+            <label><input type="radio" name="q18" value="b">It uses helical gears for the final reduction.</label>
+            <label><input type="radio" name="q18" value="c">It offers only one path-of-power and one gear reduction through the drive pinion and crown gear.</label>
+            <label><input type="radio" name="q18" value="d">It uses an outboard planetary final drive.</label>
         </div>
 
         <div class="question">
             <p><strong>In a single-speed double reduction carrier assembly, the second gear reduction is accomplished through a set of:</strong></p>
-            <label><input type="radio" name="q19" value="a"> A. Hypoid gears.</label>
-            <label><input type="radio" name="q19" value="b"> B. Straight spur gears.</label>
-            <label><input type="radio" name="q19" value="c"> C. Helical gears.</label>
-            <label><input type="radio" name="q19" value="d"> D. Spiral bevel gears.</label>
+            <label><input type="radio" name="q19" value="a">Hypoid gears.</label>
+            <label><input type="radio" name="q19" value="b">Straight spur gears.</label>
+            <label><input type="radio" name="q19" value="c">Helical gears.</label>
+            <label><input type="radio" name="q19" value="d">Spiral bevel gears.</label>
         </div>
 
         <div class="question">
             <p><strong>What is the common name given to the component that houses the bearings supporting the drive pinion, and may be a removable piece of the carrier housing?</strong></p>
-            <label><input type="radio" name="q20" value="a"> A. Differential Housing</label>
-            <label><input type="radio" name="q20" value="b"> B. Pinion Bearing Cage</label>
-            <label><input type="radio" name="q20" value="c"> C. Differential Case Half</label>
-            <label><input type="radio" name="q20" value="d"> D. Ring Gear Mount Assembly</label>
+            <label><input type="radio" name="q20" value="a">Differential Housing</label>
+            <label><input type="radio" name="q20" value="b">Pinion Bearing Cage</label>
+            <label><input type="radio" name="q20" value="c">Differential Case Half</label>
+            <label><input type="radio" name="q20" value="d">Ring Gear Mount Assembly</label>
         </div>
 
         <div class="question">
             <p><strong>What component is used as a selective spacer to determine the pinion bearing preload in the pinion cage assembly?</strong></p>
-            <label><input type="radio" name="q21" value="a"> A. Pinion position shims</label>
-            <label><input type="radio" name="q21" value="b"> B. Drive pinion nut</label>
-            <label><input type="radio" name="q21" value="c"> C. Pinion preload spacer</label>
-            <label><input type="radio" name="q21" value="d"> D. Outer pinion bearing cup</label>
+            <label><input type="radio" name="q21" value="a">Pinion position shims</label>
+            <label><input type="radio" name="q21" value="b">Drive pinion nut</label>
+            <label><input type="radio" name="q21" value="c">Pinion preload spacer</label>
+            <label><input type="radio" name="q21" value="d">Outer pinion bearing cup</label>
         </div>
 
         <div class="question">
             <p><strong>What design feature characterizes an overhung mount input drive pinion when viewed from the side?</strong></p>
-            <label><input type="radio" name="q22" value="a"> A. A pilot bearing surface that extends past the end of the gear.</label>
-            <label><input type="radio" name="q22" value="b"> B. A flat surface at the end of the pinion gear (flat pinion face).</label>
-            <label><input type="radio" name="q22" value="c"> C. It meshes with the crown gear below the centerline.</label>
-            <label><input type="radio" name="q22" value="d"> D. It uses three sets of tapered roller bearings.</label>
+            <label><input type="radio" name="q22" value="a">A pilot bearing surface that extends past the end of the gear.</label>
+            <label><input type="radio" name="q22" value="b">A flat surface at the end of the pinion gear (flat pinion face).</label>
+            <label><input type="radio" name="q22" value="c">It meshes with the crown gear below the centerline.</label>
+            <label><input type="radio" name="q22" value="d">It uses three sets of tapered roller bearings.</label>
         </div>
 
         <div class="question">
             <p><strong>Why is a special thrust screw and jam nut sometimes used on drive axle assemblies?</strong></p>
-            <label><input type="radio" name="q23" value="a"> A. To adjust the backlash between the differential side gears.</label>
-            <label><input type="radio" name="q23" value="b"> B. To help prevent the crown gear from deflecting away from the pinion during high torque load.</label>
-            <label><input type="radio" name="q23" value="c"> C. To provide a mounting surface for the differential bearing adjuster.</label>
-            <label><input type="radio" name="q23" value="d"> D. To secure the pinion bearing cage to the carrier housing.</label>
+            <label><input type="radio" name="q23" value="a">To adjust the backlash between the differential side gears.</label>
+            <label><input type="radio" name="q23" value="b">To help prevent the crown gear from deflecting away from the pinion during high torque load.</label>
+            <label><input type="radio" name="q23" value="c">To provide a mounting surface for the differential bearing adjuster.</label>
+            <label><input type="radio" name="q23" value="d">To secure the pinion bearing cage to the carrier housing.</label>
         </div>
 
         <div class="question">
             <p><strong>The differential case assembly is composed of two halves (a flanged and a plain) that are bolted together and supported by which type of bearing on either end?</strong></p>
-            <label><input type="radio" name="q24" value="a"> A. Ball bearings</label>
-            <label><input type="radio" name="q24" value="b"> B. Straight roller bearings</label>
-            <label><input type="radio" name="q24" value="c"> C. Tapered roller bearings</label>
-            <label><input type="radio" name="q24" value="d"> D. Pilot bushings</label>
+            <label><input type="radio" name="q24" value="a">Ball bearings</label>
+            <label><input type="radio" name="q24" value="b">Straight roller bearings</label>
+            <label><input type="radio" name="q24" value="c">Tapered roller bearings</label>
+            <label><input type="radio" name="q24" value="d">Pilot bushings</label>
         </div>
 
         <div class="question">
             <p><strong>The crown gear is bolted to which specific component in the differential case assembly?</strong></p>
-            <label><input type="radio" name="q25" value="a"> A. The plain case half</label>
-            <label><input type="radio" name="q25" value="b"> B. The differential cross shaft</label>
-            <label><input type="radio" name="q25" value="c"> C. The flanged differential case half</label>
-            <label><input type="radio" name="q25" value="d"> D. The differential side gear</label>
+            <label><input type="radio" name="q25" value="a">The plain case half</label>
+            <label><input type="radio" name="q25" value="b">The differential cross shaft</label>
+            <label><input type="radio" name="q25" value="c">The flanged differential case half</label>
+            <label><input type="radio" name="q25" value="d">The differential side gear</label>
         </div>
 
         <div class="question">
             <p><strong>The differential cross shaft, often called the spider, is connected to and driven by:</strong></p>
-            <label><input type="radio" name="q26" value="a"> A. Splines on the axle shaft.</label>
-            <label><input type="radio" name="q26" value="b"> B. The differential pinion gears.</label>
-            <label><input type="radio" name="q26" value="c"> C. Recesses machined into the differential case halves.</label>
-            <label><input type="radio" name="q26" value="d"> D. The ring gear bolts.</label>
+            <label><input type="radio" name="q26" value="a">Splines on the axle shaft.</label>
+            <label><input type="radio" name="q26" value="b">The differential pinion gears.</label>
+            <label><input type="radio" name="q26" value="c">Recesses machined into the differential case halves.</label>
+            <label><input type="radio" name="q26" value="d">The ring gear bolts.</label>
         </div>
 
         <div class="question">
             <p><strong>What components are placed between the differential pinion gears and the differential case assembly?</strong></p>
-            <label><input type="radio" name="q27" value="a"> A. Pinion position shims</label>
-            <label><input type="radio" name="q27" value="b"> B. Thrust washers</label>
-            <label><input type="radio" name="q27" value="c"> C. Bearing adjuster rings</label>
-            <label><input type="radio" name="q27" value="d"> D. Spring retainers</label>
+            <label><input type="radio" name="q27" value="a">Pinion position shims</label>
+            <label><input type="radio" name="q27" value="b">Thrust washers</label>
+            <label><input type="radio" name="q27" value="c">Bearing adjuster rings</label>
+            <label><input type="radio" name="q27" value="d">Spring retainers</label>
         </div>
 
         <div class="question">
             <p><strong>The axle side gears are the final components in the differential case assembly and mate with the splines on each axle shaft. The axle side gears are in mesh with which other gears?</strong></p>
-            <label><input type="radio" name="q28" value="a"> A. The crown/ring gear</label>
-            <label><input type="radio" name="q28" value="b"> B. The differential pinion gears</label>
-            <label><input type="radio" name="q28" value="c"> C. The helical drive gear</label>
-            <label><input type="radio" name="q28" value="d"> D. The input pinion</label>
+            <label><input type="radio" name="q28" value="a">The crown/ring gear</label>
+            <label><input type="radio" name="q28" value="b">The differential pinion gears</label>
+            <label><input type="radio" name="q28" value="c">The helical drive gear</label>
+            <label><input type="radio" name="q28" value="d">The input pinion</label>
         </div>
 
         <div class="question">
             <p><strong>If a vehicle equipped with a standard differential is turning a corner, what is the differential's function concerning torque delivery?</strong></p>
-            <label><input type="radio" name="q29" value="a"> A. Torque is increased to the wheel on the outside of the turn.</label>
-            <label><input type="radio" name="q29" value="b"> B. Torque is transferred entirely to the wheel with the most traction.</label>
-            <label><input type="radio" name="q29" value="c"> C. Torque is always divided equally between the two drive wheels.</label>
-            <label><input type="radio" name="q29" value="d"> D. Torque is reduced to compensate for the difference in wheel speeds.</label>
+            <label><input type="radio" name="q29" value="a">Torque is increased to the wheel on the outside of the turn.</label>
+            <label><input type="radio" name="q29" value="b">Torque is transferred entirely to the wheel with the most traction.</label>
+            <label><input type="radio" name="q29" value="c">Torque is always divided equally between the two drive wheels.</label>
+            <label><input type="radio" name="q29" value="d">Torque is reduced to compensate for the difference in wheel speeds.</label>
         </div>
 
         <div class="question">
             <p><strong>The No-Spin traction control unit replaces which standard differential components?</strong></p>
-            <label><input type="radio" name="q30" value="a"> A. The ring gear and differential case.</label>
-            <label><input type="radio" name="q30" value="b"> B. The axle side gears and axle shafts.</label>
-            <label><input type="radio" name="q30" value="c"> C. The standard cross shaft, differential pinions, and axle side gears.</label>
-            <label><input type="radio" name="q30" value="d"> D. The differential case halves and the spider.</label>
+            <label><input type="radio" name="q30" value="a">The ring gear and differential case.</label>
+            <label><input type="radio" name="q30" value="b">The axle side gears and axle shafts.</label>
+            <label><input type="radio" name="q30" value="c">The standard cross shaft, differential pinions, and axle side gears.</label>
+            <label><input type="radio" name="q30" value="d">The differential case halves and the spider.</label>
         </div>
 
         <div class="question">
             <p><strong>In a No-Spin unit during normal locked operation, what component remains stationary relative to the rotating spider and driven clutch members?</strong></p>
-            <label><input type="radio" name="q31" value="a"> A. The outer drive axle shaft.</label>
-            <label><input type="radio" name="q31" value="b"> B. Nothing; all parts rotate at the same speed.</label>
-            <label><input type="radio" name="q31" value="c"> C. The spring retainer.</label>
-            <label><input type="radio" name="q31" value="d"> D. The holdout ring.</label>
+            <label><input type="radio" name="q31" value="a">The outer drive axle shaft.</label>
+            <label><input type="radio" name="q31" value="b">Nothing; all parts rotate at the same speed.</label>
+            <label><input type="radio" name="q31" value="c">The spring retainer.</label>
+            <label><input type="radio" name="q31" value="d">The holdout ring.</label>
         </div>
 
         <div class="question">
             <p><strong>What condition causes the driven clutch in a No-Spin unit to disengage (overrun) when a vehicle is turning a corner?</strong></p>
-            <label><input type="radio" name="q32" value="a"> A. The inner wheel rotates faster than the spider.</label>
-            <label><input type="radio" name="q32" value="b"> B. The outer wheel travels faster than the inner wheel and has enough traction to drive the outer driven clutch faster than the spider.</label>
-            <label><input type="radio" name="q32" value="c"> C. The operator applies the service brake.</label>
-            <label><input type="radio" name="q32" value="d"> D. The spring pressure on the clutch plates is eliminated.</label>
+            <label><input type="radio" name="q32" value="a">The inner wheel rotates faster than the spider.</label>
+            <label><input type="radio" name="q32" value="b">The outer wheel travels faster than the inner wheel and has enough traction to drive the outer driven clutch faster than the spider.</label>
+            <label><input type="radio" name="q32" value="c">The operator applies the service brake.</label>
+            <label><input type="radio" name="q32" value="d">The spring pressure on the clutch plates is eliminated.</label>
         </div>
 
         <div class="question">
             <p><strong>What is the normal noise that occurs during the cornering process of a vehicle equipped with a No-Spin unit?</strong></p>
-            <label><input type="radio" name="q33" value="a"> A. A grinding sound indicating pinion gear failure.</label>
-            <label><input type="radio" name="q33" value="b"> B. A steady howl indicative of backlash problems.</label>
-            <label><input type="radio" name="q33" value="c"> C. A ratcheting noise due to the disengaging and engaging of the clutching teeth.</label>
-            <label><input type="radio" name="q33" value="d"> D. A squealing noise caused by poor lubrication.</label>
+            <label><input type="radio" name="q33" value="a">A grinding sound indicating pinion gear failure.</label>
+            <label><input type="radio" name="q33" value="b">A steady howl indicative of backlash problems.</label>
+            <label><input type="radio" name="q33" value="c">A ratcheting noise due to the disengaging and engaging of the clutching teeth.</label>
+            <label><input type="radio" name="q33" value="d">A squealing noise caused by poor lubrication.</label>
         </div>
 
         <div class="question">
             <p><strong>A Driver-Controlled Axle Differential Lock allows the operator to mechanically connect which two components together when poor traction is encountered?</strong></p>
-            <label><input type="radio" name="q34" value="a"> A. The drive pinion and the differential case.</label>
-            <label><input type="radio" name="q34" value="b"> B. The axle shaft on one side and the differential case.</label>
-            <label><input type="radio" name="q34" value="c"> C. The shift collar and the rear axle housing.</label>
-            <label><input type="radio" name="q34" value="d"> D. The differential side gear and the crown/ring gear.</label>
+            <label><input type="radio" name="q34" value="a">The drive pinion and the differential case.</label>
+            <label><input type="radio" name="q34" value="b">The axle shaft on one side and the differential case.</label>
+            <label><input type="radio" name="q34" value="c">The shift collar and the rear axle housing.</label>
+            <label><input type="radio" name="q34" value="d">The differential side gear and the crown/ring gear.</label>
         </div>
 
         <div class="question">
             <p><strong>The Eaton driver-controlled wheel lock is typically operated by the driver using which two types of systems?</strong></p>
-            <label><input type="radio" name="q35" value="a"> A. Hydraulic pressure or vacuum actuation.</label>
-            <label><input type="radio" name="q35" value="b"> B. Mechanical cable or direct linkage.</label>
-            <label><input type="radio" name="q35" value="c"> C. Air switch or an electric-over-air system.</label>
-            <label><input type="radio" name="q35" value="d"> D. Torsional spring or centrifugal weights.</label>
+            <label><input type="radio" name="q35" value="a">Hydraulic pressure or vacuum actuation.</label>
+            <label><input type="radio" name="q35" value="b">Mechanical cable or direct linkage.</label>
+            <label><input type="radio" name="q35" value="c">Air switch or an electric-over-air system.</label>
+            <label><input type="radio" name="q35" value="d">Torsional spring or centrifugal weights.</label>
         </div>
 
         <div class="question">
             <p><strong>Which heavy-duty application often requires the use of an Outboard Planetary Final Drive system?</strong></p>
-            <label><input type="radio" name="q36" value="a"> A. Highway cruising vehicles with high fuel economy ratios.</label>
-            <label><input type="radio" name="q36" value="b"> B. Medium-duty trucks operating primarily on smooth pavement.</label>
-            <label><input type="radio" name="q36" value="c"> C. Heavy-duty trucks transporting heavy loads in an off-road environment.</label>
-            <label><input type="radio" name="q36" value="d"> D. Vehicles with single-speed single reduction carrier assemblies.</label>
+            <label><input type="radio" name="q36" value="a">Highway cruising vehicles with high fuel economy ratios.</label>
+            <label><input type="radio" name="q36" value="b">Medium-duty trucks operating primarily on smooth pavement.</label>
+            <label><input type="radio" name="q36" value="c">Heavy-duty trucks transporting heavy loads in an off-road environment.</label>
+            <label><input type="radio" name="q36" value="d">Vehicles with single-speed single reduction carrier assemblies.</label>
         </div>
 
         <div class="question">
             <p><strong>In an Outboard Planetary Final Drive system, what is the role of the planetary carrier assembly?</strong></p>
-            <label><input type="radio" name="q37" value="a"> A. It is the held member (stationary).</label>
-            <label><input type="radio" name="q37" value="b"> B. It is the drive member (input).</label>
-            <label><input type="radio" name="q37" value="c"> C. It is the output member, which is bolted to the hub assembly.</label>
-            <label><input type="radio" name="q37" value="d"> D. It contains the axle side gear and differential pinions.</label>
+            <label><input type="radio" name="q37" value="a">It is the held member (stationary).</label>
+            <label><input type="radio" name="q37" value="b">It is the drive member (input).</label>
+            <label><input type="radio" name="q37" value="c">It is the output member, which is bolted to the hub assembly.</label>
+            <label><input type="radio" name="q37" value="d">It contains the axle side gear and differential pinions.</label>
         </div>
 
         <div class="question">
             <p><strong>The internal gear (ring gear) in the Outboard Planetary Final Drive is the held member because it is splined to what fixed component?</strong></p>
-            <label><input type="radio" name="q38" value="a"> A. The hub assembly.</label>
-            <label><input type="radio" name="q38" value="b"> B. The spindle.</label>
-            <label><input type="radio" name="q38" value="c"> C. The sun gear.</label>
-            <label><input type="radio" name="q38" value="d"> D. The axle shaft.</label>
+            <label><input type="radio" name="q38" value="a">The hub assembly.</label>
+            <label><input type="radio" name="q38" value="b">The spindle.</label>
+            <label><input type="radio" name="q38" value="c">The sun gear.</label>
+            <label><input type="radio" name="q38" value="d">The axle shaft.</label>
         </div>
 
         <div class="question">
             <p><strong>The Inter-Axle Differential Assembly (Power Divider) is a differential that allows for speed differences to occur between the forward and rearward drive axle input pinions. This assembly is typically an integral part of which axle housing?</strong></p>
-            <label><input type="radio" name="q39" value="a"> A. The main transmission housing.</label>
-            <label><input type="radio" name="q39" value="b"> B. The rear drive axle assembly.</label>
-            <label><input type="radio" name="q39" value="c"> C. The front or intermediate drive axle assembly.</label>
-            <label><input type="radio" name="q39" value="d"> D. The dead axle assembly.</label>
+            <label><input type="radio" name="q39" value="a">The main transmission housing.</label>
+            <label><input type="radio" name="q39" value="b">The rear drive axle assembly.</label>
+            <label><input type="radio" name="q39" value="c">The front or intermediate drive axle assembly.</label>
+            <label><input type="radio" name="q39" value="d">The dead axle assembly.</label>
         </div>
 
         <div class="question">
             <p><strong>When the inter-axle differential is allowed to operate (lockout disengaged), how is torque divided between the two drive axle assemblies (forward and rearward)?</strong></p>
-            <label><input type="radio" name="q40" value="a"> A. Torque is transferred entirely to the axle with the most traction.</label>
-            <label><input type="radio" name="q40" value="b"> B. Torque is divided unevenly, favoring the forward axle.</label>
-            <label><input type="radio" name="q40" value="c"> C. Torque is divided equally between the two drive axle assemblies.</label>
-            <label><input type="radio" name="q40" value="d"> D. Torque transfer is stopped entirely.</label>
+            <label><input type="radio" name="q40" value="a">Torque is transferred entirely to the axle with the most traction.</label>
+            <label><input type="radio" name="q40" value="b">Torque is divided unevenly, favoring the forward axle.</label>
+            <label><input type="radio" name="q40" value="c">Torque is divided equally between the two drive axle assemblies.</label>
+            <label><input type="radio" name="q40" value="d">Torque transfer is stopped entirely.</label>
         </div>
 
         <div class="question">
             <p><strong>What is the functional result of mechanically locking out the inter-axle differential (lockout engaged)?</strong></p>
-            <label><input type="radio" name="q41" value="a"> A. The inter-axle differential action is temporarily eliminated, and the entire assembly turns as a solid unit.</label>
-            <label><input type="radio" name="q41" value="b"> B. The torque is diverted entirely to the rearward drive axle.</label>
-            <label><input type="radio" name="q41" value="c"> C. The truck enters a freewheeling condition.</label>
-            <label><input type="radio" name="q41" value="d"> D. The differential pinions rotate at maximum speed.</label>
+            <label><input type="radio" name="q41" value="a">The inter-axle differential action is temporarily eliminated, and the entire assembly turns as a solid unit.</label>
+            <label><input type="radio" name="q41" value="b">The torque is diverted entirely to the rearward drive axle.</label>
+            <label><input type="radio" name="q41" value="c">The truck enters a freewheeling condition.</label>
+            <label><input type="radio" name="q41" value="d">The differential pinions rotate at maximum speed.</label>
         </div>
 
         <div class="question">
             <p><strong>Under what driving condition is it CAUTIONED against locking out the inter-axle differential?</strong></p>
-            <label><input type="radio" name="q42" value="a"> A. Moving straight ahead at low speed on a slippery surface.</label>
-            <label><input type="radio" name="q42" value="b"> B. Operating the truck on dry roads or turning the truck.</label>
-            <label><input type="radio" name="q42" value="c"> C. Slowly approaching a stretch of road where traction is poor.</label>
-            <label><input type="radio" name="q42" value="d"> D. When the torque load applied is momentarily broken by easing off the throttle.</label>
+            <label><input type="radio" name="q42" value="a">Moving straight ahead at low speed on a slippery surface.</label>
+            <label><input type="radio" name="q42" value="b">Operating the truck on dry roads or turning the truck.</label>
+            <label><input type="radio" name="q42" value="c">Slowly approaching a stretch of road where traction is poor.</label>
+            <label><input type="radio" name="q42" value="d">When the torque load applied is momentarily broken by easing off the throttle.</label>
         </div>
 
         <div class="question">
             <p><strong>Which type of gear oil classification (API rating) is required for hypoid gear sets?</strong></p>
-            <label><input type="radio" name="q43" value="a"> A. GL1</label>
-            <label><input type="radio" name="q43" value="b"> B. GL3</label>
-            <label><input type="radio" name="q43" value="c"> C. GL5</label>
-            <label><input type="radio" name="q43" value="d"> D. GL6</label>
+            <label><input type="radio" name="q43" value="a">GL1</label>
+            <label><input type="radio" name="q43" value="b">GL3</label>
+            <label><input type="radio" name="q43" value="c">GL5</label>
+            <label><input type="radio" name="q43" value="d">GL6</label>
         </div>
 
         <div class="question">
             <p><strong>What is the fundamental disadvantage of mixing different types of gear oil in a drive axle housing?</strong></p>
-            <label><input type="radio" name="q44" value="a"> A. The lubricant's viscosity rating will increase dramatically.</label>
-            <label><input type="radio" name="q44" value="b"> B. Mixing different types of gear oil causes a breakdown chemically.</label>
-            <label><input type="radio" name="q44" value="c"> C. The oil will resist foaming under extreme temperature.</label>
-            <label><input type="radio" name="q44" value="d"> D. The SAE designation will automatically change.</label>
+            <label><input type="radio" name="q44" value="a">The lubricant's viscosity rating will increase dramatically.</label>
+            <label><input type="radio" name="q44" value="b">Mixing different types of gear oil causes a breakdown chemically.</label>
+            <label><input type="radio" name="q44" value="c">The oil will resist foaming under extreme temperature.</label>
+            <label><input type="radio" name="q44" value="d">The SAE designation will automatically change.</label>
         </div>
 
         <div class="question">
             <p><strong>The full synthetic gear lubricants offer which specific benefit over traditional gear oils?</strong></p>
-            <label><input type="radio" name="q45" value="a"> A. They maintain a lower cost per litre.</label>
-            <label><input type="radio" name="q45" value="b"> B. They reduce bearing and gear distress only at high temperatures.</label>
-            <label><input type="radio" name="q45" value="c"> C. They reduce bearing and gear distress under extreme operating conditions (high and low temperatures).</label>
-            <label><input type="radio" name="q45" value="d"> D. They are resistant to oxidation but not to corrosion.</label>
+            <label><input type="radio" name="q45" value="a">They maintain a lower cost per litre.</label>
+            <label><input type="radio" name="q45" value="b">They reduce bearing and gear distress only at high temperatures.</label>
+            <label><input type="radio" name="q45" value="c">They reduce bearing and gear distress under extreme operating conditions (high and low temperatures).</label>
+            <label><input type="radio" name="q45" value="d">They are resistant to oxidation but not to corrosion.</label>
         </div>
 
         <div class="question">
             <p><strong>The vast majority of drive axle assemblies are lubricated using which basic system?</strong></p>
-            <label><input type="radio" name="q46" value="a"> A. Dedicated pressure pump and filter system.</label>
-            <label><input type="radio" name="q46" value="b"> B. Fluid transfer pump system.</label>
-            <label><input type="radio" name="q46" value="c"> C. Splash lubrication system, where the crown gear moves through an oil reservoir.</label>
-            <label><input type="radio" name="q46" value="d"> D. Combination pressure/gravity feed system.</label>
+            <label><input type="radio" name="q46" value="a">Dedicated pressure pump and filter system.</label>
+            <label><input type="radio" name="q46" value="b">Fluid transfer pump system.</label>
+            <label><input type="radio" name="q46" value="c">Splash lubrication system, where the crown gear moves through an oil reservoir.</label>
+            <label><input type="radio" name="q46" value="d">Combination pressure/gravity feed system.</label>
         </div>
 
         <div class="question">
             <p><strong>Why do some manufacturers install a lube pump in the front or intermediate differential carrier assemblies on a tandem axle combination?</strong></p>
-            <label><input type="radio" name="q47" value="a"> A. To ensure the pinion bearings receive adequate lubrication when the axle is cold.</label>
-            <label><input type="radio" name="q47" value="b"> B. To offer lubrication to the inter-axle differential assembly that cannot be reached by splash lubrication, especially during a wheel spin.</label>
-            <label><input type="radio" name="q47" value="c"> C. To provide a high-pressure oil flow to the wheel ends.</label>
-            <label><input type="radio" name="q47" value="d"> D. To continuously filter the gear oil using a magnetic drain plug.</label>
+            <label><input type="radio" name="q47" value="a">To ensure the pinion bearings receive adequate lubrication when the axle is cold.</label>
+            <label><input type="radio" name="q47" value="b">To offer lubrication to the inter-axle differential assembly that cannot be reached by splash lubrication, especially during a wheel spin.</label>
+            <label><input type="radio" name="q47" value="c">To provide a high-pressure oil flow to the wheel ends.</label>
+            <label><input type="radio" name="q47" value="d">To continuously filter the gear oil using a magnetic drain plug.</label>
         </div>
 
         <div class="question">
             <p><strong>If the differential is equipped with an oil pump, what filtration component is installed on the pickup to trap materials before the pump ingests them?</strong></p>
-            <label><input type="radio" name="q48" value="a"> A. Spin-on oil filter</label>
-            <label><input type="radio" name="q48" value="b"> B. Magnetic screen</label>
-            <label><input type="radio" name="q48" value="c"> C. Dedicated drain plug</label>
-            <label><input type="radio" name="q48" value="d"> D. Oil trough</label>
+            <label><input type="radio" name="q48" value="a">Spin-on oil filter</label>
+            <label><input type="radio" name="q48" value="b">Magnetic screen</label>
+            <label><input type="radio" name="q48" value="c">Dedicated drain plug</label>
+            <label><input type="radio" name="q48" value="d">Oil trough</label>
         </div>
 
         <div class="question">
             <p><strong>When the drive pinion nut fails, which selective component must be recommended as a related sale?</strong></p>
-            <label><input type="radio" name="q49" value="a"> A. Pinion position shim</label>
-            <label><input type="radio" name="q49" value="b"> B. Differential cross shaft</label>
-            <label><input type="radio" name="q49" value="c"> C. Crush sleeve</label>
-            <label><input type="radio" name="q49" value="d"> D. Differential gear</label>
+            <label><input type="radio" name="q49" value="a">Pinion position shim</label>
+            <label><input type="radio" name="q49" value="b">Differential cross shaft</label>
+            <label><input type="radio" name="q49" value="c">Crush sleeve</label>
+            <label><input type="radio" name="q49" value="d">Differential gear</label>
         </div>
 
         <div class="question">
             <p><strong>If a customer is ordering a remanufactured drive axle unit, what essential information must the parts technician relay to the customer regarding the old unit?</strong></p>
-            <label><input type="radio" name="q50" value="a"> A. That all parts are guaranteed to be new and carry a lifetime warranty.</label>
-            <label><input type="radio" name="q50" value="b"> B. That the customer will be charged a core charge and must return the old axle assembly (core) to receive a credit.</label>
-            <label><input type="radio" name="q50" value="c"> C. That the unit will be shipped without bearings and seals.</label>
-            <label><input type="radio" name="q50" value="d"> D. That the unit must be custom rebuilt as the supplier has no units in stock.</label>
+            <label><input type="radio" name="q50" value="a">That all parts are guaranteed to be new and carry a lifetime warranty.</label>
+            <label><input type="radio" name="q50" value="b">That the customer will be charged a core charge and must return the old axle assembly (core) to receive a credit.</label>
+            <label><input type="radio" name="q50" value="c">That the unit will be shipped without bearings and seals.</label>
+            <label><input type="radio" name="q50" value="d">That the unit must be custom rebuilt as the supplier has no units in stock.</label>
         </div>
 
 <div class="exam-actions">

--- a/270202-test/270202i - All-Wheel Drive.html
+++ b/270202-test/270202i - All-Wheel Drive.html
@@ -71,402 +71,402 @@
 
    <div class="question">
         <p><strong>When fully applied, the NVG-246 multi-plate friction clutch assembly is capable of transmitting a maximum of how much torque to the front drive axle assembly?</strong></p>
-        <label><input type="radio" name="q1" value="a"> A. Up to 400 ft/lb of torque</label>
-        <label><input type="radio" name="q1" value="b"> B. Up to 600 ft/lb of torque</label>
-        <label><input type="radio" name="q1" value="c"> C. Up to 800 ft/lb of torque</label>
-        <label><input type="radio" name="q1" value="d"> D. Up to 1200 ft/lb of torque</label>
+        <label><input type="radio" name="q1" value="a">Up to 400 ft/lb of torque</label>
+        <label><input type="radio" name="q1" value="b">Up to 600 ft/lb of torque</label>
+        <label><input type="radio" name="q1" value="c">Up to 800 ft/lb of torque</label>
+        <label><input type="radio" name="q1" value="d">Up to 1200 ft/lb of torque</label>
       </div>
 
       <div class="question">
         <p><strong>A viscous coupling utilized in a full-time transfer case is designed to lock up and deliver power to the axle with traction when the rate of slippage between the front and rear axles approaches what percentage?</strong></p>
-        <label><input type="radio" name="q2" value="a"> A. 2%</label>
-        <label><input type="radio" name="q2" value="b"> B. 6%</label>
-        <label><input type="radio" name="q2" value="c"> C. 10%</label>
-        <label><input type="radio" name="q2" value="d"> D. 12%</label>
+        <label><input type="radio" name="q2" value="a">2%</label>
+        <label><input type="radio" name="q2" value="b">6%</label>
+        <label><input type="radio" name="q2" value="c">10%</label>
+        <label><input type="radio" name="q2" value="d">12%</label>
       </div>
 
       <div class="question">
         <p><strong>In a viscous coupling, if the fluid temperature remains below 93.3 ° C (200 ° F), what state does the special silicone liquid maintain?</strong></p>
-        <label><input type="radio" name="q3" value="a"> A. The liquid immediately thickens due to shearing action.</label>
-        <label><input type="radio" name="q3" value="b"> B. The liquid remains thin, allowing no slippage.</label>
-        <label><input type="radio" name="q3" value="c"> C. The liquid remains thick, resulting in a locked AWD condition.</label>
-        <label><input type="radio" name="q3" value="d"> D. The liquid remains thin, allowing slip to occur without torque transfer.</label>
+        <label><input type="radio" name="q3" value="a">The liquid immediately thickens due to shearing action.</label>
+        <label><input type="radio" name="q3" value="b">The liquid remains thin, allowing no slippage.</label>
+        <label><input type="radio" name="q3" value="c">The liquid remains thick, resulting in a locked AWD condition.</label>
+        <label><input type="radio" name="q3" value="d">The liquid remains thin, allowing slip to occur without torque transfer.</label>
       </div>
 
       <div class="question">
         <p><strong>How many separate speed sensors are mounted on the NV-246 electronic transfer case?</strong></p>
-        <label><input type="radio" name="q4" value="a"> A. Two sensors (Front and Rear output)</label>
-        <label><input type="radio" name="q4" value="b"> B. Three sensors (Vehicle Speed, Front Output, Rear Output)</label>
-        <label><input type="radio" name="q4" value="c"> C. Four sensors (One on each output shaft, one on input, one VSS)</label>
-        <label><input type="radio" name="q4" value="d"> D. Only one sensor (the VSS)</label>
+        <label><input type="radio" name="q4" value="a">Two sensors (Front and Rear output)</label>
+        <label><input type="radio" name="q4" value="b">Three sensors (Vehicle Speed, Front Output, Rear Output)</label>
+        <label><input type="radio" name="q4" value="c">Four sensors (One on each output shaft, one on input, one VSS)</label>
+        <label><input type="radio" name="q4" value="d">Only one sensor (the VSS)</label>
       </div>
 
       <div class="question">
         <p><strong>What is the main purpose of four-wheel drive (4WD) and all-wheel drive (AWD) systems?</strong></p>
-        <label><input type="radio" name="q5" value="a"> A. To increase vehicle speed during off-road driving.</label>
-        <label><input type="radio" name="q5" value="b"> B. To eliminate the need for a differential lock.</label>
-        <label><input type="radio" name="q5" value="c"> C. To increase traction on slippery road surfaces.</label>
-        <label><input type="radio" name="q5" value="d"> D. To equalize the torque split between the front and rear axles.</label>
+        <label><input type="radio" name="q5" value="a">To increase vehicle speed during off-road driving.</label>
+        <label><input type="radio" name="q5" value="b">To eliminate the need for a differential lock.</label>
+        <label><input type="radio" name="q5" value="c">To increase traction on slippery road surfaces.</label>
+        <label><input type="radio" name="q5" value="d">To equalize the torque split between the front and rear axles.</label>
       </div>
 
       <div class="question">
         <p><strong>In the auto industry, what condition typically defines an All-Wheel Drive (AWD) system?</strong></p>
-        <label><input type="radio" name="q6" value="a"> A. The system must always be manually engaged by the driver.</label>
-        <label><input type="radio" name="q6" value="b"> B. The system must be part-time and disengage entirely above 50 mph.</label>
-        <label><input type="radio" name="q6" value="c"> C. The system is permanently engaged or automatically engaging four-wheel drive.</label>
-        <label><input type="radio" name="q6" value="d"> D. The system requires manual locking hubs on the front wheels.</label>
+        <label><input type="radio" name="q6" value="a">The system must always be manually engaged by the driver.</label>
+        <label><input type="radio" name="q6" value="b">The system must be part-time and disengage entirely above 50 mph.</label>
+        <label><input type="radio" name="q6" value="c">The system is permanently engaged or automatically engaging four-wheel drive.</label>
+        <label><input type="radio" name="q6" value="d">The system requires manual locking hubs on the front wheels.</label>
       </div>
 
       <div class="question">
         <p><strong>A vehicle requires the driver to manually engage the system when extra traction is needed. This system is typically classified as what type of drive?</strong></p>
-        <label><input type="radio" name="q7" value="a"> A. Full-Time Four-Wheel Drive</label>
-        <label><input type="radio" name="q7" value="b"> B. All-Wheel Drive (AWD)</label>
-        <label><input type="radio" name="q7" value="c"> C. Part-Time Four-Wheel Drive</label>
-        <label><input type="radio" name="q7" value="d"> D. Viscous Biasing Unit Drive</label>
+        <label><input type="radio" name="q7" value="a">Full-Time Four-Wheel Drive</label>
+        <label><input type="radio" name="q7" value="b">All-Wheel Drive (AWD)</label>
+        <label><input type="radio" name="q7" value="c">Part-Time Four-Wheel Drive</label>
+        <label><input type="radio" name="q7" value="d">Viscous Biasing Unit Drive</label>
       </div>
 
       <div class="question">
         <p><strong>What is the purpose of the transfer case in any four-wheel or all-wheel drive vehicle?</strong></p>
-        <label><input type="radio" name="q8" value="a"> A. To provide a second gear reduction to increase top speed.</label>
-        <label><input type="radio" name="q8" value="b"> B. To automatically shift the transmission based on traction loss.</label>
-        <label><input type="radio" name="q8" value="c"> C. To divide the power coming from the transmission between the front and rear wheels.</label>
-        <label><input type="radio" name="q8" value="d"> D. To lock the front axle shafts together when reversing.</label>
+        <label><input type="radio" name="q8" value="a">To provide a second gear reduction to increase top speed.</label>
+        <label><input type="radio" name="q8" value="b">To automatically shift the transmission based on traction loss.</label>
+        <label><input type="radio" name="q8" value="c">To divide the power coming from the transmission between the front and rear wheels.</label>
+        <label><input type="radio" name="q8" value="d">To lock the front axle shafts together when reversing.</label>
       </div>
 
       <div class="question">
         <p><strong>What component must be added to a conventional rear-wheel drive vehicle to create a four-wheel drive system that directs engine power to both the front and rear wheels?</strong></p>
-        <label><input type="radio" name="q9" value="a"> A. A torque converter</label>
-        <label><input type="radio" name="q9" value="b"> B. A center differential</label>
-        <label><input type="radio" name="q9" value="c"> C. A manual transfer case</label>
-        <label><input type="radio" name="q9" value="d"> D. A propeller shaft</label>
+        <label><input type="radio" name="q9" value="a">A torque converter</label>
+        <label><input type="radio" name="q9" value="b">A center differential</label>
+        <label><input type="radio" name="q9" value="c">A manual transfer case</label>
+        <label><input type="radio" name="q9" value="d">A propeller shaft</label>
       </div>
 
       <div class="question">
         <p><strong>The three major types of four-wheel drive systems are part-time, full-time, and all-wheel drive. What dictates which type of transfer case is required for a vehicle?</strong></p>
-        <label><input type="radio" name="q10" value="a"> A. The type of front drive axle used (semi-floating or full-floating).</label>
-        <label><input type="radio" name="q10" value="b"> B. The housing material (cast iron, aluminum, or magnesium).</label>
-        <label><input type="radio" name="q10" value="c"> C. Each system requires its own unique transfer case.</label>
-        <label><input type="radio" name="q10" value="d"> D. The required maximum transfer case torque capacity.</label>
+        <label><input type="radio" name="q10" value="a">The type of front drive axle used (semi-floating or full-floating).</label>
+        <label><input type="radio" name="q10" value="b">The housing material (cast iron, aluminum, or magnesium).</label>
+        <label><input type="radio" name="q10" value="c">Each system requires its own unique transfer case.</label>
+        <label><input type="radio" name="q10" value="d">The required maximum transfer case torque capacity.</label>
       </div>
 
       <div class="question">
         <p><strong>What action must the driver take to disengage the front wheels from the drive axle when a vehicle is equipped with manual locking hubs?</strong></p>
-        <label><input type="radio" name="q11" value="a"> A. Shift the transfer case into 2H and wait for the front axle to disengage automatically.</label>
-        <label><input type="radio" name="q11" value="b"> B. Turn the locking hub to the &quot;FREE&quot; or unlocked position.</label>
-        <label><input type="radio" name="q11" value="c"> C. Turn the hub to the &quot;LOCK&quot; position and shift the transfer case into 4L.</label>
-        <label><input type="radio" name="q11" value="d"> D. Stop the vehicle completely and back up one to two metres.</label>
+        <label><input type="radio" name="q11" value="a">Shift the transfer case into 2H and wait for the front axle to disengage automatically.</label>
+        <label><input type="radio" name="q11" value="b">Turn the locking hub to the &quot;FREE&quot; or unlocked position.</label>
+        <label><input type="radio" name="q11" value="c">Turn the hub to the &quot;LOCK&quot; position and shift the transfer case into 4L.</label>
+        <label><input type="radio" name="q11" value="d">Stop the vehicle completely and back up one to two metres.</label>
       </div>
 
       <div class="question">
         <p><strong>What action is required to unlock automatic locking hubs after operating the vehicle in four-wheel drive?</strong></p>
-        <label><input type="radio" name="q12" value="a"> A. Simply shifting the transfer case back into 2H.</label>
-        <label><input type="radio" name="q12" value="b"> B. Driving forward slowly while turning the steering wheel sharply.</label>
-        <label><input type="radio" name="q12" value="c"> C. Completely stopping the vehicle, shifting out of four-wheel drive, and backing the vehicle up one to two metres (three to six feet).</label>
-        <label><input type="radio" name="q12" value="d"> D. Applying the clutch brake while shifting into neutral.</label>
+        <label><input type="radio" name="q12" value="a">Simply shifting the transfer case back into 2H.</label>
+        <label><input type="radio" name="q12" value="b">Driving forward slowly while turning the steering wheel sharply.</label>
+        <label><input type="radio" name="q12" value="c">Completely stopping the vehicle, shifting out of four-wheel drive, and backing the vehicle up one to two metres (three to six feet).</label>
+        <label><input type="radio" name="q12" value="d">Applying the clutch brake while shifting into neutral.</label>
       </div>
 
       <div class="question">
         <p><strong>In a gear type transfer case operating in 2H position, why do the front drive high gear and the front drive low gear rotate, even though no power is transmitted through them to the front output shaft?</strong></p>
-        <label><input type="radio" name="q13" value="a"> A. They are hydraulically locked to the rear output shaft.</label>
-        <label><input type="radio" name="q13" value="b"> B. They are in constant mesh with the idler gear and input gear.</label>
-        <label><input type="radio" name="q13" value="c"> C. The front output shaft is manually locked to the rear output shaft.</label>
-        <label><input type="radio" name="q13" value="d"> D. The 4WD clutch is moved toward the input gear.</label>
+        <label><input type="radio" name="q13" value="a">They are hydraulically locked to the rear output shaft.</label>
+        <label><input type="radio" name="q13" value="b">They are in constant mesh with the idler gear and input gear.</label>
+        <label><input type="radio" name="q13" value="c">The front output shaft is manually locked to the rear output shaft.</label>
+        <label><input type="radio" name="q13" value="d">The 4WD clutch is moved toward the input gear.</label>
       </div>
 
       <div class="question">
         <p><strong>What is the final component in the path of power for the rear wheels when a gear type transfer case is operating in 2H (two-wheel drive high range)?</strong></p>
-        <label><input type="radio" name="q14" value="a"> A. The input gear.</label>
-        <label><input type="radio" name="q14" value="b"> B. The range clutch.</label>
-        <label><input type="radio" name="q14" value="c"> C. The rear output shaft.</label>
-        <label><input type="radio" name="q14" value="d"> D. The rear drive low gear.</label>
+        <label><input type="radio" name="q14" value="a">The input gear.</label>
+        <label><input type="radio" name="q14" value="b">The range clutch.</label>
+        <label><input type="radio" name="q14" value="c">The rear output shaft.</label>
+        <label><input type="radio" name="q14" value="d">The rear drive low gear.</label>
       </div>
 
       <div class="question">
         <p><strong>To achieve power transmission to the front wheels in 4H position (four-wheel drive high range) in a gear type transfer case, which two components must engage?</strong></p>
-        <label><input type="radio" name="q15" value="a"> A. The range clutch must lock the rear drive low gear and the 4WD clutch must lock the rear output shaft.</label>
-        <label><input type="radio" name="q15" value="b"> B. The range clutch must lock the rear output shaft and the 4WD clutch must lock the rear drive low gear.</label>
-        <label><input type="radio" name="q15" value="c"> C. The range clutch must move toward the input gear, and the 4WD clutch must move toward the front drive high gear.</label>
-        <label><input type="radio" name="q15" value="d"> D. The idler gear must lock to the front drive high gear.</label>
+        <label><input type="radio" name="q15" value="a">The range clutch must lock the rear drive low gear and the 4WD clutch must lock the rear output shaft.</label>
+        <label><input type="radio" name="q15" value="b">The range clutch must lock the rear output shaft and the 4WD clutch must lock the rear drive low gear.</label>
+        <label><input type="radio" name="q15" value="c">The range clutch must move toward the input gear, and the 4WD clutch must move toward the front drive high gear.</label>
+        <label><input type="radio" name="q15" value="d">The idler gear must lock to the front drive high gear.</label>
       </div>
 
       <div class="question">
         <p><strong>Which component, driven by the front drive high gear, transfers torque directly to the front axle assembly in the 4H position?</strong></p>
-        <label><input type="radio" name="q16" value="a"> A. The rear drive low gear</label>
-        <label><input type="radio" name="q16" value="b"> B. The idler gear</label>
-        <label><input type="radio" name="q16" value="c"> C. The front output shaft</label>
-        <label><input type="radio" name="q16" value="d"> D. The range clutch</label>
+        <label><input type="radio" name="q16" value="a">The rear drive low gear</label>
+        <label><input type="radio" name="q16" value="b">The idler gear</label>
+        <label><input type="radio" name="q16" value="c">The front output shaft</label>
+        <label><input type="radio" name="q16" value="d">The range clutch</label>
       </div>
 
       <div class="question">
         <p><strong>To create the 4L range in a gear type transfer case, the range clutch locks the rear drive low gear to the rear output shaft, and the 4WD clutch locks the front drive low gear to which component?</strong></p>
-        <label><input type="radio" name="q17" value="a"> A. The input gear</label>
-        <label><input type="radio" name="q17" value="b"> B. The idler shaft</label>
-        <label><input type="radio" name="q17" value="c"> C. The front output shaft</label>
-        <label><input type="radio" name="q17" value="d"> D. The range shift hub</label>
+        <label><input type="radio" name="q17" value="a">The input gear</label>
+        <label><input type="radio" name="q17" value="b">The idler shaft</label>
+        <label><input type="radio" name="q17" value="c">The front output shaft</label>
+        <label><input type="radio" name="q17" value="d">The range shift hub</label>
       </div>
 
       <div class="question">
         <p><strong>What is the fundamental characteristic of Full-Time Transfer Cases regarding driver engagement?</strong></p>
-        <label><input type="radio" name="q18" value="a"> A. They are manually engaged only when the vehicle is stopped.</label>
-        <label><input type="radio" name="q18" value="b"> B. They are not engaged and disengaged by the driver; all four wheels are driven whenever the vehicle is moving.</label>
-        <label><input type="radio" name="q18" value="c"> C. They are automatically engaged only when the vehicle is in 4L.</label>
-        <label><input type="radio" name="q18" value="d"> D. They are engaged using special locking hubs.</label>
+        <label><input type="radio" name="q18" value="a">They are manually engaged only when the vehicle is stopped.</label>
+        <label><input type="radio" name="q18" value="b">They are not engaged and disengaged by the driver; all four wheels are driven whenever the vehicle is moving.</label>
+        <label><input type="radio" name="q18" value="c">They are automatically engaged only when the vehicle is in 4L.</label>
+        <label><input type="radio" name="q18" value="d">They are engaged using special locking hubs.</label>
       </div>
 
       <div class="question">
         <p><strong>Why were full-time transfer cases originally developed?</strong></p>
-        <label><input type="radio" name="q19" value="a"> A. To allow the use of a simple gear-type transfer case.</label>
-        <label><input type="radio" name="q19" value="b"> B. To eliminate the need for a front drive axle.</label>
-        <label><input type="radio" name="q19" value="c"> C. To prevent wheel spin at the axle with the least amount of traction.</label>
-        <label><input type="radio" name="q19" value="d"> D. To provide deep reduction gearing for heavy off-road use.</label>
+        <label><input type="radio" name="q19" value="a">To allow the use of a simple gear-type transfer case.</label>
+        <label><input type="radio" name="q19" value="b">To eliminate the need for a front drive axle.</label>
+        <label><input type="radio" name="q19" value="c">To prevent wheel spin at the axle with the least amount of traction.</label>
+        <label><input type="radio" name="q19" value="d">To provide deep reduction gearing for heavy off-road use.</label>
       </div>
 
       <div class="question">
         <p><strong>When a vehicle with a full-time transfer case turns a corner, what is the required function of the transfer case to prevent driveline binding?</strong></p>
-        <label><input type="radio" name="q20" value="a"> A. The front axle must be temporarily locked out.</label>
-        <label><input type="radio" name="q20" value="b"> B. It must allow the front and rear drive axles to turn at different speeds.</label>
-        <label><input type="radio" name="q20" value="c"> C. It must utilize a 4WD clutch to lock the front and rear output shafts together.</label>
-        <label><input type="radio" name="q20" value="d"> D. It must ensure the wheels on the inside and outside of the turn make the same arc.</label>
+        <label><input type="radio" name="q20" value="a">The front axle must be temporarily locked out.</label>
+        <label><input type="radio" name="q20" value="b">It must allow the front and rear drive axles to turn at different speeds.</label>
+        <label><input type="radio" name="q20" value="c">It must utilize a 4WD clutch to lock the front and rear output shafts together.</label>
+        <label><input type="radio" name="q20" value="d">It must ensure the wheels on the inside and outside of the turn make the same arc.</label>
       </div>
 
       <div class="question">
         <p><strong>What component may be incorporated into a full-time transfer case to allow the front and rear drive axles to turn at different speeds?</strong></p>
-        <label><input type="radio" name="q21" value="a"> A. A locking hub system</label>
-        <label><input type="radio" name="q21" value="b"> B. A differential or a viscous coupling.</label>
-        <label><input type="radio" name="q21" value="c"> C. A planetary reduction gear set only</label>
-        <label><input type="radio" name="q21" value="d"> D. A clutch brake assembly</label>
+        <label><input type="radio" name="q21" value="a">A locking hub system</label>
+        <label><input type="radio" name="q21" value="b">A differential or a viscous coupling.</label>
+        <label><input type="radio" name="q21" value="c">A planetary reduction gear set only</label>
+        <label><input type="radio" name="q21" value="d">A clutch brake assembly</label>
       </div>
 
       <div class="question">
         <p><strong>What is the purpose of the center differential in an AWD system?</strong></p>
-        <label><input type="radio" name="q22" value="a"> A. To provide a second torque reduction in 4L.</label>
-        <label><input type="radio" name="q22" value="b"> B. To compensate for rotational speed differences between the front and rear wheel axles generated during turning.</label>
-        <label><input type="radio" name="q22" value="c"> C. To provide the locking force for the viscous coupling.</label>
-        <label><input type="radio" name="q22" value="d"> D. To transfer all torque to the rear axle under normal driving.</label>
+        <label><input type="radio" name="q22" value="a">To provide a second torque reduction in 4L.</label>
+        <label><input type="radio" name="q22" value="b">To compensate for rotational speed differences between the front and rear wheel axles generated during turning.</label>
+        <label><input type="radio" name="q22" value="c">To provide the locking force for the viscous coupling.</label>
+        <label><input type="radio" name="q22" value="d">To transfer all torque to the rear axle under normal driving.</label>
       </div>
 
       <div class="question">
         <p><strong>When one of the tires in an AWD vehicle loses grip and keeps spinning, why is the center differential alone typically insufficient to maintain traction?</strong></p>
-        <label><input type="radio" name="q23" value="a"> A. The bevelled gear mechanism cannot withstand high torque loads.</label>
-        <label><input type="radio" name="q23" value="b"> B. The planetary gearing creates a 1:1 ratio under slip.</label>
-        <label><input type="radio" name="q23" value="c"> C. Its design characteristics are such that it is not able to transmit the traction to the rest of the tires gripping the road surface.</label>
-        <label><input type="radio" name="q23" value="d"> D. The viscous coupling fluid remains thin below 200 ° F.</label>
+        <label><input type="radio" name="q23" value="a">The bevelled gear mechanism cannot withstand high torque loads.</label>
+        <label><input type="radio" name="q23" value="b">The planetary gearing creates a 1:1 ratio under slip.</label>
+        <label><input type="radio" name="q23" value="c">Its design characteristics are such that it is not able to transmit the traction to the rest of the tires gripping the road surface.</label>
+        <label><input type="radio" name="q23" value="d">The viscous coupling fluid remains thin below 200 ° F.</label>
       </div>
 
       <div class="question">
         <p><strong>To limit the rotational differences between the front and rear axles in a full-time center differential, the system must have a mechanism, which in the source example is described as a:</strong></p>
-        <label><input type="radio" name="q24" value="a"> A. Centrifugal locking dog clutch.</label>
-        <label><input type="radio" name="q24" value="b"> B. Permanent magnet motor lock.</label>
-        <label><input type="radio" name="q24" value="c"> C. Hydraulically operated multiple plate clutch.</label>
-        <label><input type="radio" name="q24" value="d"> D. Manually operated locking hub system.</label>
+        <label><input type="radio" name="q24" value="a">Centrifugal locking dog clutch.</label>
+        <label><input type="radio" name="q24" value="b">Permanent magnet motor lock.</label>
+        <label><input type="radio" name="q24" value="c">Hydraulically operated multiple plate clutch.</label>
+        <label><input type="radio" name="q24" value="d">Manually operated locking hub system.</label>
       </div>
 
       <div class="question">
         <p><strong>In the hydraulically operated multiple plate clutch used in an AWD center differential, the clutch is typically controlled by outputs from which electronic module?</strong></p>
-        <label><input type="radio" name="q25" value="a"> A. Powertrain Control Module (PCM)</label>
-        <label><input type="radio" name="q25" value="b"> B. Transmission Control Module (TCM) outputs to a duty solenoid.</label>
-        <label><input type="radio" name="q25" value="c"> C. Automatic Transfer Case Control Module (ATCM)</label>
-        <label><input type="radio" name="q25" value="d"> D. Vehicle Speed Sensor (VSS)</label>
+        <label><input type="radio" name="q25" value="a">Powertrain Control Module (PCM)</label>
+        <label><input type="radio" name="q25" value="b">Transmission Control Module (TCM) outputs to a duty solenoid.</label>
+        <label><input type="radio" name="q25" value="c">Automatic Transfer Case Control Module (ATCM)</label>
+        <label><input type="radio" name="q25" value="d">Vehicle Speed Sensor (VSS)</label>
       </div>
 
       <div class="question">
         <p><strong>During normal straight-ahead driving, the multiple plate clutch in an AWD center differential is in which state?</strong></p>
-        <label><input type="radio" name="q26" value="a"> A. Fully engaged, creating a rigid AWD condition.</label>
-        <label><input type="radio" name="q26" value="b"> B. Released, allowing the center differential to compensate for speed differences.</label>
-        <label><input type="radio" name="q26" value="c"> C. Partially engaged, providing 6% slip resistance.</label>
-        <label><input type="radio" name="q26" value="d"> D. Locked by the duty solenoid.</label>
+        <label><input type="radio" name="q26" value="a">Fully engaged, creating a rigid AWD condition.</label>
+        <label><input type="radio" name="q26" value="b">Released, allowing the center differential to compensate for speed differences.</label>
+        <label><input type="radio" name="q26" value="c">Partially engaged, providing 6% slip resistance.</label>
+        <label><input type="radio" name="q26" value="d">Locked by the duty solenoid.</label>
       </div>
 
       <div class="question">
         <p><strong>When a slipping condition causes the hydraulic multiple plate clutch to engage in the center differential, what is the resulting mechanical condition?</strong></p>
-        <label><input type="radio" name="q27" value="a"> A. The differential gears lock, but the axles remain unlocked.</label>
-        <label><input type="radio" name="q27" value="b"> B. The front axle is disengaged, and power is sent only to the rear.</label>
-        <label><input type="radio" name="q27" value="c"> C. The front and rear axles are directly connected, producing a rigid AWD condition.</label>
-        <label><input type="radio" name="q27" value="d"> D. The planetary carrier freewheels, stopping torque transfer.</label>
+        <label><input type="radio" name="q27" value="a">The differential gears lock, but the axles remain unlocked.</label>
+        <label><input type="radio" name="q27" value="b">The front axle is disengaged, and power is sent only to the rear.</label>
+        <label><input type="radio" name="q27" value="c">The front and rear axles are directly connected, producing a rigid AWD condition.</label>
+        <label><input type="radio" name="q27" value="d">The planetary carrier freewheels, stopping torque transfer.</label>
       </div>
 
       <div class="question">
         <p><strong>In a planetary gear center differential (Figure 14), which component is defined as the output member that transfers power to the front wheels?</strong></p>
-        <label><input type="radio" name="q28" value="a"> A. The 1 st Sun Gear.</label>
-        <label><input type="radio" name="q28" value="b"> B. The Intermediate Shaft.</label>
-        <label><input type="radio" name="q28" value="c"> C. The Reduction Drive Gear installed to the carrier.</label>
-        <label><input type="radio" name="q28" value="d"> D. The Rear Drive Shaft.</label>
+        <label><input type="radio" name="q28" value="a">The 1 st Sun Gear.</label>
+        <label><input type="radio" name="q28" value="b">The Intermediate Shaft.</label>
+        <label><input type="radio" name="q28" value="c">The Reduction Drive Gear installed to the carrier.</label>
+        <label><input type="radio" name="q28" value="d">The Rear Drive Shaft.</label>
       </div>
 
       <div class="question">
         <p><strong>What is the core mechanism by which a viscous coupling (Figure 11) locks up to transfer torque when slippage occurs?</strong></p>
-        <label><input type="radio" name="q29" value="a"> A. The mechanical connection between input and output disks locks upon contact.</label>
-        <label><input type="radio" name="q29" value="b"> B. The differential case is actuated by the electric shift motor.</label>
-        <label><input type="radio" name="q29" value="c"> C. The shearing action of the fluid between the slipping disks drives up the temperature, causing the silicone liquid to quickly thicken.</label>
-        <label><input type="radio" name="q29" value="d"> D. The perforated disks are splined directly to the front and rear axles.</label>
+        <label><input type="radio" name="q29" value="a">The mechanical connection between input and output disks locks upon contact.</label>
+        <label><input type="radio" name="q29" value="b">The differential case is actuated by the electric shift motor.</label>
+        <label><input type="radio" name="q29" value="c">The shearing action of the fluid between the slipping disks drives up the temperature, causing the silicone liquid to quickly thicken.</label>
+        <label><input type="radio" name="q29" value="d">The perforated disks are splined directly to the front and rear axles.</label>
       </div>
 
       <div class="question">
         <p><strong>In an AWD system with a viscous coupling, what occurs if the front wheels begin to slip?</strong></p>
-        <label><input type="radio" name="q30" value="a"> A. The rear differential is unlocked, removing power from the rear wheels.</label>
-        <label><input type="radio" name="q30" value="b"> B. The speed sensor sends a signal to the ATCM to manually engage the front axle.</label>
-        <label><input type="radio" name="q30" value="c"> C. The fluid coupling locks up and delivers power to the rear axle.</label>
-        <label><input type="radio" name="q30" value="d"> D. The front axle locking mechanism is automatically disengaged.</label>
+        <label><input type="radio" name="q30" value="a">The rear differential is unlocked, removing power from the rear wheels.</label>
+        <label><input type="radio" name="q30" value="b">The speed sensor sends a signal to the ATCM to manually engage the front axle.</label>
+        <label><input type="radio" name="q30" value="c">The fluid coupling locks up and delivers power to the rear axle.</label>
+        <label><input type="radio" name="q30" value="d">The front axle locking mechanism is automatically disengaged.</label>
       </div>
 
       <div class="question">
         <p><strong>All-wheel drive vehicles, such as those equipped with a viscous coupling unit, are typically designed for which purpose?</strong></p>
-        <label><input type="radio" name="q31" value="a"> A. Heavy-duty off-road use and shallow water fording.</label>
-        <label><input type="radio" name="q31" value="b"> B. Improved traction on slippery road surfaces such as wet, ice, or snow.</label>
-        <label><input type="radio" name="q31" value="c"> C. Constant velocity operation at extreme drive angles.</label>
-        <label><input type="radio" name="q31" value="d"> D. Eliminating the need for a clutch and transmission.</label>
+        <label><input type="radio" name="q31" value="a">Heavy-duty off-road use and shallow water fording.</label>
+        <label><input type="radio" name="q31" value="b">Improved traction on slippery road surfaces such as wet, ice, or snow.</label>
+        <label><input type="radio" name="q31" value="c">Constant velocity operation at extreme drive angles.</label>
+        <label><input type="radio" name="q31" value="d">Eliminating the need for a clutch and transmission.</label>
       </div>
 
       <div class="question">
         <p><strong>What component is required in a part-time transfer case (Model 241) to ensure the proper transfer of power from the rear output shaft to the front output shaft?</strong></p>
-        <label><input type="radio" name="q32" value="a"> A. A planetary gear set.</label>
-        <label><input type="radio" name="q32" value="b"> B. A chain drive.</label>
-        <label><input type="radio" name="q32" value="c"> C. A viscous coupling.</label>
-        <label><input type="radio" name="q32" value="d"> D. A mechanical linkage.</label>
+        <label><input type="radio" name="q32" value="a">A planetary gear set.</label>
+        <label><input type="radio" name="q32" value="b">A chain drive.</label>
+        <label><input type="radio" name="q32" value="c">A viscous coupling.</label>
+        <label><input type="radio" name="q32" value="d">A mechanical linkage.</label>
       </div>
 
       <div class="question">
         <p><strong>Which component, shown in the exploded view of the Model 241 transfer case (Table 1), is intended to collect metal fragments and protect internal components?</strong></p>
-        <label><input type="radio" name="q33" value="a"> A. Deflector (80)</label>
-        <label><input type="radio" name="q33" value="b"> B. Oil pump screen (28)</label>
-        <label><input type="radio" name="q33" value="c"> C. Magnet (26)</label>
-        <label><input type="radio" name="q33" value="d"> D. Breather (1)</label>
+        <label><input type="radio" name="q33" value="a">Deflector (80)</label>
+        <label><input type="radio" name="q33" value="b">Oil pump screen (28)</label>
+        <label><input type="radio" name="q33" value="c">Magnet (26)</label>
+        <label><input type="radio" name="q33" value="d">Breather (1)</label>
       </div>
 
       <div class="question">
         <p><strong>How is the NV-246 electronic transfer case encoder motor controlled by the Automatic Transfer Case Control Module (ATCM)?</strong></p>
-        <label><input type="radio" name="q34" value="a"> A. Via a dedicated hydraulic pressure circuit.</label>
-        <label><input type="radio" name="q34" value="b"> B. With a pulse width modulated (PWM) circuit provided by the ATCM.</label>
-        <label><input type="radio" name="q34" value="c"> C. By a mechanical cable connected directly to the shift switch.</label>
-        <label><input type="radio" name="q34" value="d"> D. Through an electric solenoid that locks the sector shaft.</label>
+        <label><input type="radio" name="q34" value="a">Via a dedicated hydraulic pressure circuit.</label>
+        <label><input type="radio" name="q34" value="b">With a pulse width modulated (PWM) circuit provided by the ATCM.</label>
+        <label><input type="radio" name="q34" value="c">By a mechanical cable connected directly to the shift switch.</label>
+        <label><input type="radio" name="q34" value="d">Through an electric solenoid that locks the sector shaft.</label>
       </div>
 
       <div class="question">
         <p><strong>The NV-246 transfer case encoder motor consists of a permanent magnet (PM) DC motor and which other component assembly?</strong></p>
-        <label><input type="radio" name="q35" value="a"> A. A centrifugal weight system.</label>
-        <label><input type="radio" name="q35" value="b"> B. A gear reduction gear assembly.</label>
-        <label><input type="radio" name="q35" value="c"> C. A planetary carrier lock.</label>
-        <label><input type="radio" name="q35" value="d"> D. A multi-plate friction clutch.</label>
+        <label><input type="radio" name="q35" value="a">A centrifugal weight system.</label>
+        <label><input type="radio" name="q35" value="b">A gear reduction gear assembly.</label>
+        <label><input type="radio" name="q35" value="c">A planetary carrier lock.</label>
+        <label><input type="radio" name="q35" value="d">A multi-plate friction clutch.</label>
       </div>
 
       <div class="question">
         <p><strong>What is the purpose of the transfer case motor lock, which is part of the motor assembly?</strong></p>
-        <label><input type="radio" name="q36" value="a"> A. To engage the front axle clutch pack immediately upon startup.</label>
-        <label><input type="radio" name="q36" value="b"> B. To prevent the transfer case from changing mode/gear positions or popping out of position.</label>
-        <label><input type="radio" name="q36" value="c"> C. To provide the necessary torque to the front propeller shaft.</label>
-        <label><input type="radio" name="q36" value="d"> D. To allow the encoder motor to rotate only clockwise.</label>
+        <label><input type="radio" name="q36" value="a">To engage the front axle clutch pack immediately upon startup.</label>
+        <label><input type="radio" name="q36" value="b">To prevent the transfer case from changing mode/gear positions or popping out of position.</label>
+        <label><input type="radio" name="q36" value="c">To provide the necessary torque to the front propeller shaft.</label>
+        <label><input type="radio" name="q36" value="d">To allow the encoder motor to rotate only clockwise.</label>
       </div>
 
       <div class="question">
         <p><strong>In the NV-246 system, when the transfer case is placed in 2HI,4HI, or 4LO, what is the state of the motor lock circuit?</strong></p>
-        <label><input type="radio" name="q37" value="a"> A. The lock circuit is energized, allowing the encoder motor to rotate.</label>
-        <label><input type="radio" name="q37" value="b"> B. The motor lock circuit has no voltage provided to it, applying the lock.</label>
-        <label><input type="radio" name="q37" value="c"> C. The circuit is open, allowing the transfer of torque to the front axle.</label>
-        <label><input type="radio" name="q37" value="d"> D. The circuit flashes repeatedly to warn the driver.</label>
+        <label><input type="radio" name="q37" value="a">The lock circuit is energized, allowing the encoder motor to rotate.</label>
+        <label><input type="radio" name="q37" value="b">The motor lock circuit has no voltage provided to it, applying the lock.</label>
+        <label><input type="radio" name="q37" value="c">The circuit is open, allowing the transfer of torque to the front axle.</label>
+        <label><input type="radio" name="q37" value="d">The circuit flashes repeatedly to warn the driver.</label>
       </div>
 
       <div class="question">
         <p><strong>The 4LO setting on the NV-246 transfer case is used when driving off-road in deep mud or climbing steep hills because it delivers extra torque by:</strong></p>
-        <label><input type="radio" name="q38" value="a"> A. Disengaging the rear output shaft completely.</label>
-        <label><input type="radio" name="q38" value="b"> B. Applying the clutch brake.</label>
-        <label><input type="radio" name="q38" value="c"> C. Lowering the applied gear ratio.</label>
-        <label><input type="radio" name="q38" value="d"> D. Automatically engaging the front axle motor lock.</label>
+        <label><input type="radio" name="q38" value="a">Disengaging the rear output shaft completely.</label>
+        <label><input type="radio" name="q38" value="b">Applying the clutch brake.</label>
+        <label><input type="radio" name="q38" value="c">Lowering the applied gear ratio.</label>
+        <label><input type="radio" name="q38" value="d">Automatically engaging the front axle motor lock.</label>
       </div>
 
       <div class="question">
         <p><strong>The 2HI setting on the NV-246 transfer case is used for normal driving with power sent only to the rear wheels. This setting also provides what specific operational advantage?</strong></p>
-        <label><input type="radio" name="q39" value="a"> A. Maximum torque delivery.</label>
-        <label><input type="radio" name="q39" value="b"> B. The best fuel economy.</label>
-        <label><input type="radio" name="q39" value="c"> C. The ability to shift-on-the-fly.</label>
-        <label><input type="radio" name="q39" value="d"> D. Automatic engagement of four-wheel drive.</label>
+        <label><input type="radio" name="q39" value="a">Maximum torque delivery.</label>
+        <label><input type="radio" name="q39" value="b">The best fuel economy.</label>
+        <label><input type="radio" name="q39" value="c">The ability to shift-on-the-fly.</label>
+        <label><input type="radio" name="q39" value="d">Automatic engagement of four-wheel drive.</label>
       </div>
 
       <div class="question">
         <p><strong>If the indicator light on the NV-246 selector switch flashes the selected gear repeatedly for 30 seconds and then returns to the last chosen setting, what condition does this indicate?</strong></p>
-        <label><input type="radio" name="q40" value="a"> A. The shift is complete and the system is operating normally.</label>
-        <label><input type="radio" name="q40" value="b"> B. The transfer case has shifted successfully into Neutral.</label>
-        <label><input type="radio" name="q40" value="c"> C. The transfer case cannot make a requested shift.</label>
-        <label><input type="radio" name="q40" value="d"> D. The ATCM has successfully accessed VIN information.</label>
+        <label><input type="radio" name="q40" value="a">The shift is complete and the system is operating normally.</label>
+        <label><input type="radio" name="q40" value="b">The transfer case has shifted successfully into Neutral.</label>
+        <label><input type="radio" name="q40" value="c">The transfer case cannot make a requested shift.</label>
+        <label><input type="radio" name="q40" value="d">The ATCM has successfully accessed VIN information.</label>
       </div>
 
       <div class="question">
         <p><strong>What is the role of the Transfer Case Encoder Assembly?</strong></p>
-        <label><input type="radio" name="q41" value="a"> A. It mechanically rotates the sector shaft to shift the transfer case.</label>
-        <label><input type="radio" name="q41" value="b"> B. It applies pressure to the clutch pack when required.</label>
-        <label><input type="radio" name="q41" value="c"> C. It converts the current sector shaft position (mode or range) into electrical signal inputs to the transfer case shift control module.</label>
-        <label><input type="radio" name="q41" value="d"> D. It provides the pulse width modulated signal to the motor.</label>
+        <label><input type="radio" name="q41" value="a">It mechanically rotates the sector shaft to shift the transfer case.</label>
+        <label><input type="radio" name="q41" value="b">It applies pressure to the clutch pack when required.</label>
+        <label><input type="radio" name="q41" value="c">It converts the current sector shaft position (mode or range) into electrical signal inputs to the transfer case shift control module.</label>
+        <label><input type="radio" name="q41" value="d">It provides the pulse width modulated signal to the motor.</label>
       </div>
 
       <div class="question">
         <p><strong>What are the two primary components that the Automatic Transfer Case Control Module (ATCM) controls on an electronic 4WD system?</strong></p>
-        <label><input type="radio" name="q42" value="a"> A. The speed sensors and the 4WD indicator.</label>
-        <label><input type="radio" name="q42" value="b"> B. The transfer case switch assembly and the 4WD clutch.</label>
-        <label><input type="radio" name="q42" value="c"> C. The transfer case encoder motor assembly and the front axle motor assembly (to engage/disengage the front axle).</label>
-        <label><input type="radio" name="q42" value="d"> D. The PCM and the VIN information.</label>
+        <label><input type="radio" name="q42" value="a">The speed sensors and the 4WD indicator.</label>
+        <label><input type="radio" name="q42" value="b">The transfer case switch assembly and the 4WD clutch.</label>
+        <label><input type="radio" name="q42" value="c">The transfer case encoder motor assembly and the front axle motor assembly (to engage/disengage the front axle).</label>
+        <label><input type="radio" name="q42" value="d">The PCM and the VIN information.</label>
       </div>
 
       <div class="question">
         <p><strong>Which electronic system provides the necessary calibration data (based on axle ratio, transmission, tire size, and engine) to the ATCM via the on-vehicle network?</strong></p>
-        <label><input type="radio" name="q43" value="a"> A. The Driver Information Centre (DIC)</label>
-        <label><input type="radio" name="q43" value="b"> B. The Vehicle Speed Sensor (VSS)</label>
-        <label><input type="radio" name="q43" value="c"> C. The Powertrain Control Module (PCM)</label>
-        <label><input type="radio" name="q43" value="d"> D. The front output shaft speed sensor</label>
+        <label><input type="radio" name="q43" value="a">The Driver Information Centre (DIC)</label>
+        <label><input type="radio" name="q43" value="b">The Vehicle Speed Sensor (VSS)</label>
+        <label><input type="radio" name="q43" value="c">The Powertrain Control Module (PCM)</label>
+        <label><input type="radio" name="q43" value="d">The front output shaft speed sensor</label>
       </div>
 
       <div class="question">
         <p><strong>When the transfer case shift control module detects a fault in the electronic system, what is likely to occur?</strong></p>
-        <label><input type="radio" name="q44" value="a"> A. The ATCM is permanently locked out of 4HI.</label>
-        <label><input type="radio" name="q44" value="b"> B. A service 4WD lamp or warning message appears, and a Diagnostic Trouble Code (DTC) is likely set.</label>
-        <label><input type="radio" name="q44" value="c"> C. The motor lock remains energized continuously.</label>
-        <label><input type="radio" name="q44" value="d"> D. The clutch assembly capacity is automatically reduced to 400 ft/lb.</label>
+        <label><input type="radio" name="q44" value="a">The ATCM is permanently locked out of 4HI.</label>
+        <label><input type="radio" name="q44" value="b">A service 4WD lamp or warning message appears, and a Diagnostic Trouble Code (DTC) is likely set.</label>
+        <label><input type="radio" name="q44" value="c">The motor lock remains energized continuously.</label>
+        <label><input type="radio" name="q44" value="d">The clutch assembly capacity is automatically reduced to 400 ft/lb.</label>
       </div>
 
       <div class="question">
         <p><strong>The Front Output Shaft Speed Sensor is used by the ATCM in Auto 4WD mode to monitor the difference between front and rear speeds and to determine what two critical operational metrics?</strong></p>
-        <label><input type="radio" name="q45" value="a"> A. The pinion gear depth and backlash.</label>
-        <label><input type="radio" name="q45" value="b"> B. The VSS reference speed and the gear reduction ratio.</label>
-        <label><input type="radio" name="q45" value="c"> C. The amount of slip and the percent of torque to apply to the front axle.</label>
-        <label><input type="radio" name="q45" value="d"> D. The maximum rotation speed of the encoder motor.</label>
+        <label><input type="radio" name="q45" value="a">The pinion gear depth and backlash.</label>
+        <label><input type="radio" name="q45" value="b">The VSS reference speed and the gear reduction ratio.</label>
+        <label><input type="radio" name="q45" value="c">The amount of slip and the percent of torque to apply to the front axle.</label>
+        <label><input type="radio" name="q45" value="d">The maximum rotation speed of the encoder motor.</label>
       </div>
 
       <div class="question">
         <p><strong>When a transfer case fails, what component is listed in the sources as a mandatory related sales opportunity?</strong></p>
-        <label><input type="radio" name="q46" value="a"> A. Locking hubs</label>
-        <label><input type="radio" name="q46" value="b"> B. U-joints</label>
-        <label><input type="radio" name="q46" value="c"> C. Seals</label>
-        <label><input type="radio" name="q46" value="d"> D. Wheel studs</label>
+        <label><input type="radio" name="q46" value="a">Locking hubs</label>
+        <label><input type="radio" name="q46" value="b">U-joints</label>
+        <label><input type="radio" name="q46" value="c">Seals</label>
+        <label><input type="radio" name="q46" value="d">Wheel studs</label>
       </div>
 
       <div class="question">
         <p><strong>When a customer is buying replacement parts for a transfer case assembly, what information is necessary for proper component identification?</strong></p>
-        <label><input type="radio" name="q47" value="a"> A. The last four digits of the VIN.</label>
-        <label><input type="radio" name="q47" value="b"> B. The stamping number or tag number found in the parts catalogue.</label>
-        <label><input type="radio" name="q47" value="c"> C. The name of the clutch pack manufacturer.</label>
-        <label><input type="radio" name="q47" value="d"> D. The required maximum operating temperature.</label>
+        <label><input type="radio" name="q47" value="a">The last four digits of the VIN.</label>
+        <label><input type="radio" name="q47" value="b">The stamping number or tag number found in the parts catalogue.</label>
+        <label><input type="radio" name="q47" value="c">The name of the clutch pack manufacturer.</label>
+        <label><input type="radio" name="q47" value="d">The required maximum operating temperature.</label>
       </div>
 
       <div class="question">
         <p><strong>If a clutch pack (viscous coupling) fails in an AWD system, which component is listed as a related sales item?</strong></p>
-        <label><input type="radio" name="q48" value="a"> A. Differential lube</label>
-        <label><input type="radio" name="q48" value="b"> B. Axle retaining nut</label>
-        <label><input type="radio" name="q48" value="c"> C. U-joints</label>
-        <label><input type="radio" name="q48" value="d"> D. Front axle motor</label>
+        <label><input type="radio" name="q48" value="a">Differential lube</label>
+        <label><input type="radio" name="q48" value="b">Axle retaining nut</label>
+        <label><input type="radio" name="q48" value="c">U-joints</label>
+        <label><input type="radio" name="q48" value="d">Front axle motor</label>
       </div>
 
       <div class="question">
         <p><strong>What is the operational distinction between the two types of speed sensors on the rear output shaft?</strong></p>
-        <label><input type="radio" name="q49" value="a"> A. One is a high-speed sensor, and the other is a low-speed sensor.</label>
-        <label><input type="radio" name="q49" value="b"> B. One is digital, and the other is analog.</label>
-        <label><input type="radio" name="q49" value="c"> C. One is the Vehicle Speed Sensor (VSS) used as the reference speed, and the other is the rear output shaft speed sensor for ATCM calculations.</label>
-        <label><input type="radio" name="q49" value="d"> D. One reads speed in km/h, and the other reads speed in rpm.</label>
+        <label><input type="radio" name="q49" value="a">One is a high-speed sensor, and the other is a low-speed sensor.</label>
+        <label><input type="radio" name="q49" value="b">One is digital, and the other is analog.</label>
+        <label><input type="radio" name="q49" value="c">One is the Vehicle Speed Sensor (VSS) used as the reference speed, and the other is the rear output shaft speed sensor for ATCM calculations.</label>
+        <label><input type="radio" name="q49" value="d">One reads speed in km/h, and the other reads speed in rpm.</label>
       </div>
 
       <div class="question">
         <p><strong>The terms driveshaft and propeller shaft are often used interchangeably in the context of four-wheel and all-wheel drive systems. What other pair of terms are explicitly noted as interchangeable in the sources?</strong></p>
-        <label><input type="radio" name="q50" value="a"> A. Transfer case and Transaxle</label>
-        <label><input type="radio" name="q50" value="b"> B. Differential and Viscous Coupling</label>
-        <label><input type="radio" name="q50" value="c"> C. All-wheel drive and Four-wheel drive</label>
-        <label><input type="radio" name="q50" value="d"> D. Encoder Motor and Solenoid</label>
+        <label><input type="radio" name="q50" value="a">Transfer case and Transaxle</label>
+        <label><input type="radio" name="q50" value="b">Differential and Viscous Coupling</label>
+        <label><input type="radio" name="q50" value="c">All-wheel drive and Four-wheel drive</label>
+        <label><input type="radio" name="q50" value="d">Encoder Motor and Solenoid</label>
       </div>
 
 <div class="exam-actions">

--- a/270202-test/270202j - Automatic Transmission Fundamentals.html
+++ b/270202-test/270202j - Automatic Transmission Fundamentals.html
@@ -71,402 +71,402 @@
 
 <div class="question">
         <p><strong>What are the three major functional sections that make up all automatic transmissions, whether longitudinal RWD or transverse FWD transaxle units?</strong></p>
-        <label><input type="radio" name="q1" value="a"> A. Bell housing, oil pan, and extension housing.</label>
-        <label><input type="radio" name="q1" value="b"> B. Oil pump, Governor, and Drive Link assembly.</label>
-        <label><input type="radio" name="q1" value="c"> C. Torque converter, planetary gear set unit, and hydraulic control system.</label>
-        <label><input type="radio" name="q1" value="d"> D. Fluid coupling, stator support, and non-computer electrical control.</label>
+        <label><input type="radio" name="q1" value="a">Bell housing, oil pan, and extension housing.</label>
+        <label><input type="radio" name="q1" value="b">Oil pump, Governor, and Drive Link assembly.</label>
+        <label><input type="radio" name="q1" value="c">Torque converter, planetary gear set unit, and hydraulic control system.</label>
+        <label><input type="radio" name="q1" value="d">Fluid coupling, stator support, and non-computer electrical control.</label>
       </div>
 
 <div class="question">
         <p><strong>What is the main objective in the development of the automatic transmission?</strong></p>
-        <label><input type="radio" name="q2" value="a"> A. To increase the maximum available engine torque by 3.00:1.</label>
-        <label><input type="radio" name="q2" value="b"> B. To provide a permanent 1:1 ratio once the coupling point is reached.</label>
-        <label><input type="radio" name="q2" value="c"> C. To relieve the driver of the physical effort and coordination needed to operate a clutch pedal and a standard transmission shift lever.</label>
-        <label><input type="radio" name="q2" value="d"> D. To allow the engine to be started without relying on a flex plate.</label>
+        <label><input type="radio" name="q2" value="a">To increase the maximum available engine torque by 3.00:1.</label>
+        <label><input type="radio" name="q2" value="b">To provide a permanent 1:1 ratio once the coupling point is reached.</label>
+        <label><input type="radio" name="q2" value="c">To relieve the driver of the physical effort and coordination needed to operate a clutch pedal and a standard transmission shift lever.</label>
+        <label><input type="radio" name="q2" value="d">To allow the engine to be started without relying on a flex plate.</label>
       </div>
 
 <div class="question">
         <p><strong>In an automatic transmission operating in overdrive, how does the output speed and input torque compare to the input speed and output torque?</strong></p>
-        <label><input type="radio" name="q3" value="a"> A. Output speed is less than input speed, and input torque is less than output torque.</label>
-        <label><input type="radio" name="q3" value="b"> B. Output speed is equal to input speed, and torque is unchanged.</label>
-        <label><input type="radio" name="q3" value="c"> C. Output speed is greater than input speed, and input torque is greater than output torque.</label>
-        <label><input type="radio" name="q3" value="d"> D. Output speed is greater than input speed, and input torque is less than output torque.</label>
+        <label><input type="radio" name="q3" value="a">Output speed is less than input speed, and input torque is less than output torque.</label>
+        <label><input type="radio" name="q3" value="b">Output speed is equal to input speed, and torque is unchanged.</label>
+        <label><input type="radio" name="q3" value="c">Output speed is greater than input speed, and input torque is greater than output torque.</label>
+        <label><input type="radio" name="q3" value="d">Output speed is greater than input speed, and input torque is less than output torque.</label>
       </div>
 
 <div class="question">
         <p><strong>What must happen when the transmission reaches the coupling point during acceleration?</strong></p>
-        <label><input type="radio" name="q4" value="a"> A. The impeller rotation must stop instantly.</label>
-        <label><input type="radio" name="q4" value="b"> B. Torque multiplication increases rapidly to 3.00:1.</label>
-        <label><input type="radio" name="q4" value="c"> C. The stator one-way clutch must freewheel.</label>
-        <label><input type="radio" name="q4" value="d"> D. Vortex flow must be at its maximum.</label>
+        <label><input type="radio" name="q4" value="a">The impeller rotation must stop instantly.</label>
+        <label><input type="radio" name="q4" value="b">Torque multiplication increases rapidly to 3.00:1.</label>
+        <label><input type="radio" name="q4" value="c">The stator one-way clutch must freewheel.</label>
+        <label><input type="radio" name="q4" value="d">Vortex flow must be at its maximum.</label>
       </div>
 
 <div class="question">
         <p><strong>What is the approximate maximum ratio of torque multiplication provided by a three-member torque converter during a stall condition?</strong></p>
-        <label><input type="radio" name="q5" value="a"> A. 0.50:1</label>
-        <label><input type="radio" name="q5" value="b"> B. 1.00:1</label>
-        <label><input type="radio" name="q5" value="c"> C. 2.00:1 to 3.00:1</label>
-        <label><input type="radio" name="q5" value="d"> D. 4.00:1</label>
+        <label><input type="radio" name="q5" value="a">0.50:1</label>
+        <label><input type="radio" name="q5" value="b">1.00:1</label>
+        <label><input type="radio" name="q5" value="c">2.00:1 to 3.00:1</label>
+        <label><input type="radio" name="q5" value="d">4.00:1</label>
       </div>
 
 <div class="question">
         <p><strong>For practical purposes, when is the coupling point assumed to be reached in a conventional torque converter?</strong></p>
-        <label><input type="radio" name="q6" value="a"> A. When the impeller speed matches the turbine speed exactly.</label>
-        <label><input type="radio" name="q6" value="b"> B. When the vehicle reaches 65 to 95 km/h (40 to 60 mph).</label>
-        <label><input type="radio" name="q6" value="c"> C. When the turbine reaches 9/10 the speed of the impeller.</label>
-        <label><input type="radio" name="q6" value="d"> D. When the torque multiplication ratio is 2.00:1.</label>
+        <label><input type="radio" name="q6" value="a">When the impeller speed matches the turbine speed exactly.</label>
+        <label><input type="radio" name="q6" value="b">When the vehicle reaches 65 to 95 km/h (40 to 60 mph).</label>
+        <label><input type="radio" name="q6" value="c">When the turbine reaches 9/10 the speed of the impeller.</label>
+        <label><input type="radio" name="q6" value="d">When the torque multiplication ratio is 2.00:1.</label>
       </div>
 
 <div class="question">
         <p><strong>What condition occurs when the oil flow within the torque converter is termed vortex flow?</strong></p>
-        <label><input type="radio" name="q7" value="a"> A. The impeller and turbine are turning at approximately the same speed.</label>
-        <label><input type="radio" name="q7" value="b"> B. Low heat, high output speed, and low torque are created.</label>
-        <label><input type="radio" name="q7" value="c"> C. The turbine is turning at a lower rate of speed than the impeller.</label>
-        <label><input type="radio" name="q7" value="d"> D. The stator is freewheeling, allowing it to rotate clockwise.</label>
+        <label><input type="radio" name="q7" value="a">The impeller and turbine are turning at approximately the same speed.</label>
+        <label><input type="radio" name="q7" value="b">Low heat, high output speed, and low torque are created.</label>
+        <label><input type="radio" name="q7" value="c">The turbine is turning at a lower rate of speed than the impeller.</label>
+        <label><input type="radio" name="q7" value="d">The stator is freewheeling, allowing it to rotate clockwise.</label>
       </div>
 
 <div class="question">
         <p><strong>Vortex flow is greatest when the turbine is stopped and the impeller is turning as fast as the engine can, a condition known as:</strong></p>
-        <label><input type="radio" name="q8" value="a"> A. Rotary flow.</label>
-        <label><input type="radio" name="q8" value="b"> B. Coupling speed.</label>
-        <label><input type="radio" name="q8" value="c"> C. Stall condition.</label>
-        <label><input type="radio" name="q8" value="d"> D. Freewheeling.</label>
+        <label><input type="radio" name="q8" value="a">Rotary flow.</label>
+        <label><input type="radio" name="q8" value="b">Coupling speed.</label>
+        <label><input type="radio" name="q8" value="c">Stall condition.</label>
+        <label><input type="radio" name="q8" value="d">Freewheeling.</label>
       </div>
 
 <div class="question">
         <p><strong>When does rotary flow (coupling point) in a torque converter create the greatest torque output?</strong></p>
-        <label><input type="radio" name="q9" value="a"> A. Rotary flow creates maximum torque output.</label>
-        <label><input type="radio" name="q9" value="b"> B. Rotary flow is greatest when the turbine is stalled.</label>
-        <label><input type="radio" name="q9" value="c"> C. Rotary flow is not related to torque output; it is a mechanical lockup.</label>
-        <label><input type="radio" name="q9" value="d"> D. Rotary flow is greatest when torque output is the lowest.</label>
+        <label><input type="radio" name="q9" value="a">Rotary flow creates maximum torque output.</label>
+        <label><input type="radio" name="q9" value="b">Rotary flow is greatest when the turbine is stalled.</label>
+        <label><input type="radio" name="q9" value="c">Rotary flow is not related to torque output; it is a mechanical lockup.</label>
+        <label><input type="radio" name="q9" value="d">Rotary flow is greatest when torque output is the lowest.</label>
       </div>
 
 <div class="question">
         <p><strong>What is the explicit purpose of the stator in a non-lockup torque converter?</strong></p>
-        <label><input type="radio" name="q10" value="a"> A. To absorb shock loads and vibration.</label>
-        <label><input type="radio" name="q10" value="b"> B. To provide a mechanical link to the transmission gear train.</label>
-        <label><input type="radio" name="q10" value="c"> C. To intercept the oil coming out of the turbine and redirect it back to the impeller to assist rotation.</label>
-        <label><input type="radio" name="q10" value="d"> D. To provide a neutral condition at low engine RPM.</label>
+        <label><input type="radio" name="q10" value="a">To absorb shock loads and vibration.</label>
+        <label><input type="radio" name="q10" value="b">To provide a mechanical link to the transmission gear train.</label>
+        <label><input type="radio" name="q10" value="c">To intercept the oil coming out of the turbine and redirect it back to the impeller to assist rotation.</label>
+        <label><input type="radio" name="q10" value="d">To provide a neutral condition at low engine RPM.</label>
       </div>
 
 <div class="question">
         <p><strong>The redirection of oil flow by the stator increases engine torque by an approximate 2.00:1 to 3.00:1 ratio. The exact amount of torque multiplication depends on what physical characteristic of the converter?</strong></p>
-        <label><input type="radio" name="q11" value="a"> A. The material of the transmission case.</label>
-        <label><input type="radio" name="q11" value="b"> B. The thickness of the impeller drive lugs.</label>
-        <label><input type="radio" name="q11" value="c"> C. The angle of the vanes in the elements.</label>
-        <label><input type="radio" name="q11" value="d"> D. The compression of the torque converter clutch spring.</label>
+        <label><input type="radio" name="q11" value="a">The material of the transmission case.</label>
+        <label><input type="radio" name="q11" value="b">The thickness of the impeller drive lugs.</label>
+        <label><input type="radio" name="q11" value="c">The angle of the vanes in the elements.</label>
+        <label><input type="radio" name="q11" value="d">The compression of the torque converter clutch spring.</label>
       </div>
 
 <div class="question">
         <p><strong>The stator in an automatic transmission uses a one-way clutch (overrunning clutch). What is the purpose of this clutch?</strong></p>
-        <label><input type="radio" name="q12" value="a"> A. To force the stator to turn counter-clockwise against impeller rotation.</label>
-        <label><input type="radio" name="q12" value="b"> B. To lock the stator to the stator support during vortex flow.</label>
-        <label><input type="radio" name="q12" value="c"> C. To provide a frictional drag when the impeller is turning faster than the turbine.</label>
-        <label><input type="radio" name="q12" value="d"> D. To lock the turbine to the impeller at coupling speed.</label>
+        <label><input type="radio" name="q12" value="a">To force the stator to turn counter-clockwise against impeller rotation.</label>
+        <label><input type="radio" name="q12" value="b">To lock the stator to the stator support during vortex flow.</label>
+        <label><input type="radio" name="q12" value="c">To provide a frictional drag when the impeller is turning faster than the turbine.</label>
+        <label><input type="radio" name="q12" value="d">To lock the turbine to the impeller at coupling speed.</label>
       </div>
 
 <div class="question">
         <p><strong>What happens to the sprag clutch in a one-way clutch assembly when the impeller and turbine are operating at the same speed (freewheeling/overrunning)?</strong></p>
-        <label><input type="radio" name="q13" value="a"> A. The sprags pivot toward their long diagonals, locking the races.</label>
-        <label><input type="radio" name="q13" value="b"> B. The outer race rotation forces the sprags to lock the races.</label>
-        <label><input type="radio" name="q13" value="c"> C. The sprags pivot toward their short diagonals, releasing the clutch.</label>
-        <label><input type="radio" name="q13" value="d"> D. The sprags are forced to rotate at the same speed and in the same direction.</label>
+        <label><input type="radio" name="q13" value="a">The sprags pivot toward their long diagonals, locking the races.</label>
+        <label><input type="radio" name="q13" value="b">The outer race rotation forces the sprags to lock the races.</label>
+        <label><input type="radio" name="q13" value="c">The sprags pivot toward their short diagonals, releasing the clutch.</label>
+        <label><input type="radio" name="q13" value="d">The sprags are forced to rotate at the same speed and in the same direction.</label>
       </div>
 
 <div class="question">
         <p><strong>What component does the torque converter turbine element (output element) transfer power to?</strong></p>
-        <label><input type="radio" name="q14" value="a"> A. The engine flywheel (flex plate).</label>
-        <label><input type="radio" name="q14" value="b"> B. The stator support.</label>
-        <label><input type="radio" name="q14" value="c"> C. The transmission input shaft.</label>
-        <label><input type="radio" name="q14" value="d"> D. The transmission oil pump drive gear.</label>
+        <label><input type="radio" name="q14" value="a">The engine flywheel (flex plate).</label>
+        <label><input type="radio" name="q14" value="b">The stator support.</label>
+        <label><input type="radio" name="q14" value="c">The transmission input shaft.</label>
+        <label><input type="radio" name="q14" value="d">The transmission oil pump drive gear.</label>
       </div>
 
 <div class="question">
         <p><strong>What is the required condition of the stator during vehicle acceleration (before coupling speed) to achieve torque multiplication?</strong></p>
-        <label><input type="radio" name="q15" value="a"> A. Freewheeling (overrunning).</label>
-        <label><input type="radio" name="q15" value="b"> B. Rotating clockwise.</label>
-        <label><input type="radio" name="q15" value="c"> C. Held stationary (prevented from turning).</label>
-        <label><input type="radio" name="q15" value="d"> D. Turning counter-clockwise.</label>
+        <label><input type="radio" name="q15" value="a">Freewheeling (overrunning).</label>
+        <label><input type="radio" name="q15" value="b">Rotating clockwise.</label>
+        <label><input type="radio" name="q15" value="c">Held stationary (prevented from turning).</label>
+        <label><input type="radio" name="q15" value="d">Turning counter-clockwise.</label>
       </div>
 
 <div class="question">
         <p><strong>What is the fundamental difference between a fixed displacement pump and a variable displacement pump in an automatic transmission?</strong></p>
-        <label><input type="radio" name="q16" value="a"> A. Fixed displacement pumps use helical gears, while variable displacement pumps use rotor types.</label>
-        <label><input type="radio" name="q16" value="b"> B. Fixed displacement pumps draw fluid from the transmission sump, while variable displacement pumps use an external reservoir.</label>
-        <label><input type="radio" name="q16" value="c"> C. Fixed displacement pumps (gear/rotor types) discharge a constant amount of oil proportional to engine speed, while variable displacement pumps (vane type) vary output according to transmission needs.</label>
-        <label><input type="radio" name="q16" value="d"> D. Fixed displacement pumps require high pressure regulation, while variable displacement pumps do not.</label>
+        <label><input type="radio" name="q16" value="a">Fixed displacement pumps use helical gears, while variable displacement pumps use rotor types.</label>
+        <label><input type="radio" name="q16" value="b">Fixed displacement pumps draw fluid from the transmission sump, while variable displacement pumps use an external reservoir.</label>
+        <label><input type="radio" name="q16" value="c">Fixed displacement pumps (gear/rotor types) discharge a constant amount of oil proportional to engine speed, while variable displacement pumps (vane type) vary output according to transmission needs.</label>
+        <label><input type="radio" name="q16" value="d">Fixed displacement pumps require high pressure regulation, while variable displacement pumps do not.</label>
       </div>
 
 <div class="question">
         <p><strong>Gear-type pumps are often referred to as crescent pumps for what reason?</strong></p>
-        <label><input type="radio" name="q17" value="a"> A. They use gears that mesh at a 90 ∘ angle.</label>
-        <label><input type="radio" name="q17" value="b"> B. They are driven by the externally toothed gear.</label>
-        <label><input type="radio" name="q17" value="c"> C. Due to the crescent-shaped part of the body that protrudes into the area where the gears are not in mesh.</label>
-        <label><input type="radio" name="q17" value="d"> D. They are made of stamped steel, similar to the oil pan.</label>
+        <label><input type="radio" name="q17" value="a">They use gears that mesh at a 90 ∘ angle.</label>
+        <label><input type="radio" name="q17" value="b">They are driven by the externally toothed gear.</label>
+        <label><input type="radio" name="q17" value="c">Due to the crescent-shaped part of the body that protrudes into the area where the gears are not in mesh.</label>
+        <label><input type="radio" name="q17" value="d">They are made of stamped steel, similar to the oil pan.</label>
       </div>
 
 <div class="question">
         <p><strong>What is the function of the large area of the inlet port compared to the outlet port in a fixed displacement pump?</strong></p>
-        <label><input type="radio" name="q18" value="a"> A. It ensures that the fluid flow creates pressure.</label>
-        <label><input type="radio" name="q18" value="b"> B. It prevents the rotor tips from flowing between the inlet and outlet chambers.</label>
-        <label><input type="radio" name="q18" value="c"> C. It allows unrestricted oil to flow into the inlet (suction) port of the pump.</label>
-        <label><input type="radio" name="q18" value="d"> D. It reduces the discharge flow proportional to engine speed.</label>
+        <label><input type="radio" name="q18" value="a">It ensures that the fluid flow creates pressure.</label>
+        <label><input type="radio" name="q18" value="b">It prevents the rotor tips from flowing between the inlet and outlet chambers.</label>
+        <label><input type="radio" name="q18" value="c">It allows unrestricted oil to flow into the inlet (suction) port of the pump.</label>
+        <label><input type="radio" name="q18" value="d">It reduces the discharge flow proportional to engine speed.</label>
       </div>
 
 <div class="question">
         <p><strong>Automatic transmission pumps are classified as positive displacement hydraulic pumps. What does this mean concerning their operation?</strong></p>
-        <label><input type="radio" name="q19" value="a"> A. They can develop fluid flow only when the transmission is in a forward gear.</label>
-        <label><input type="radio" name="q19" value="b"> B. The pump inlet and pump outlet ports are sealed from one another.</label>
-        <label><input type="radio" name="q19" value="c"> C. They can only deliver oil when the pump is turning at engine speed.</label>
-        <label><input type="radio" name="q19" value="d"> D. They deliver more fluid than the transmission needs, resulting in excess volume.</label>
+        <label><input type="radio" name="q19" value="a">They can develop fluid flow only when the transmission is in a forward gear.</label>
+        <label><input type="radio" name="q19" value="b">The pump inlet and pump outlet ports are sealed from one another.</label>
+        <label><input type="radio" name="q19" value="c">They can only deliver oil when the pump is turning at engine speed.</label>
+        <label><input type="radio" name="q19" value="d">They deliver more fluid than the transmission needs, resulting in excess volume.</label>
       </div>
 
 <div class="question">
         <p><strong>Which component controls the output volume and system pressure of a variable displacement vane pump?</strong></p>
-        <label><input type="radio" name="q20" value="a"> A. The priming spring.</label>
-        <label><input type="radio" name="q20" value="b"> B. The slide guide ring.</label>
-        <label><input type="radio" name="q20" value="c"> C. The pressure regulator valve.</label>
-        <label><input type="radio" name="q20" value="d"> D. The torque converter hub drive gear.</label>
+        <label><input type="radio" name="q20" value="a">The priming spring.</label>
+        <label><input type="radio" name="q20" value="b">The slide guide ring.</label>
+        <label><input type="radio" name="q20" value="c">The pressure regulator valve.</label>
+        <label><input type="radio" name="q20" value="d">The torque converter hub drive gear.</label>
       </div>
 
 <div class="question">
         <p><strong>What action occurs to reduce the output volume of a variable displacement vane pump when system pressure increases?</strong></p>
-        <label><input type="radio" name="q21" value="a"> A. The pressure regulator valve closes, allowing the priming spring to expand.</label>
-        <label><input type="radio" name="q21" value="b"> B. The rotor speed is reduced by the transmission input shaft.</label>
-        <label><input type="radio" name="q21" value="c"> C. Oil is directed to the slide fluid pressure chamber, forcing the slide against the priming spring to reduce the inlet chamber size.</label>
-        <label><input type="radio" name="q21" value="d"> D. The vane guide ring is locked to the rotor assembly.</label>
+        <label><input type="radio" name="q21" value="a">The pressure regulator valve closes, allowing the priming spring to expand.</label>
+        <label><input type="radio" name="q21" value="b">The rotor speed is reduced by the transmission input shaft.</label>
+        <label><input type="radio" name="q21" value="c">Oil is directed to the slide fluid pressure chamber, forcing the slide against the priming spring to reduce the inlet chamber size.</label>
+        <label><input type="radio" name="q21" value="d">The vane guide ring is locked to the rotor assembly.</label>
       </div>
 
 <div class="question">
         <p><strong>What is the required condition for a hydraulic system to develop pressure?</strong></p>
-        <label><input type="radio" name="q22" value="a"> A. The pump must be variable displacement.</label>
-        <label><input type="radio" name="q22" value="b"> B. Its flow must be restricted or closed.</label>
-        <label><input type="radio" name="q22" value="c"> C. The fluid must be forced into the inlet side by atmospheric pressure.</label>
-        <label><input type="radio" name="q22" value="d"> D. The pump must discharge an amount of oil proportional to engine speed.</label>
+        <label><input type="radio" name="q22" value="a">The pump must be variable displacement.</label>
+        <label><input type="radio" name="q22" value="b">Its flow must be restricted or closed.</label>
+        <label><input type="radio" name="q22" value="c">The fluid must be forced into the inlet side by atmospheric pressure.</label>
+        <label><input type="radio" name="q22" value="d">The pump must discharge an amount of oil proportional to engine speed.</label>
       </div>
 
 <div class="question">
         <p><strong>The transmission oil pump must constantly circulate a small volume of oil through the converter, oil cooler, and transmission to prevent overheating. What is the ideal running temperature range for the transmission?</strong></p>
-        <label><input type="radio" name="q23" value="a"> A. Below 55 ∘C (130 ∘F).</label>
-        <label><input type="radio" name="q23" value="b"> B. 37 ∘C to 80 ∘C (100 ∘F to 175 ∘F).</label>
-        <label><input type="radio" name="q23" value="c"> C. Above 150 ∘C (300 ∘F).</label>
-        <label><input type="radio" name="q23" value="d"> D. Below 20 ∘C to prevent oxidation.</label>
+        <label><input type="radio" name="q23" value="a">Below 55 ∘C (130 ∘F).</label>
+        <label><input type="radio" name="q23" value="b">37 ∘C to 80 ∘C (100 ∘F to 175 ∘F).</label>
+        <label><input type="radio" name="q23" value="c">Above 150 ∘C (300 ∘F).</label>
+        <label><input type="radio" name="q23" value="d">Below 20 ∘C to prevent oxidation.</label>
       </div>
 
 <div class="question">
         <p><strong>Why do manufacturers build an oil cooler into the radiator, and sometimes offer an auxiliary cooler mounted in front of the radiator?</strong></p>
-        <label><input type="radio" name="q24" value="a"> A. To prevent the oil from foaming due to excessive heat.</label>
-        <label><input type="radio" name="q24" value="b"> B. To ensure the torque converter is kept full of oil under low pressure.</label>
-        <label><input type="radio" name="q24" value="c"> C. Because heavy loading or trailer hauling can cause converter temperatures to rise considerably above the ideal range.</label>
-        <label><input type="radio" name="q24" value="d"> D. To maintain fluid pressure between 30 and 70 psi.</label>
+        <label><input type="radio" name="q24" value="a">To prevent the oil from foaming due to excessive heat.</label>
+        <label><input type="radio" name="q24" value="b">To ensure the torque converter is kept full of oil under low pressure.</label>
+        <label><input type="radio" name="q24" value="c">Because heavy loading or trailer hauling can cause converter temperatures to rise considerably above the ideal range.</label>
+        <label><input type="radio" name="q24" value="d">To maintain fluid pressure between 30 and 70 psi.</label>
       </div>
 
 <div class="question">
         <p><strong>The size of an aftermarket transmission cooler is determined by the combined Gross Vehicle Weight (GVW) of which components?</strong></p>
-        <label><input type="radio" name="q25" value="a"> A. The transmission, torque converter, and engine.</label>
-        <label><input type="radio" name="q25" value="b"> B. The front and rear drive axles.</label>
-        <label><input type="radio" name="q25" value="c"> C. Both the tow vehicle and the trailer being towed.</label>
-        <label><input type="radio" name="q25" value="d"> D. The transmission and the planetary gear set.</label>
+        <label><input type="radio" name="q25" value="a">The transmission, torque converter, and engine.</label>
+        <label><input type="radio" name="q25" value="b">The front and rear drive axles.</label>
+        <label><input type="radio" name="q25" value="c">Both the tow vehicle and the trailer being towed.</label>
+        <label><input type="radio" name="q25" value="d">The transmission and the planetary gear set.</label>
       </div>
 
 <div class="question">
         <p><strong>Why is a red dye added to most automatic transmission fluids?</strong></p>
-        <label><input type="radio" name="q26" value="a"> A. To ensure non-corrosion to metal parts.</label>
-        <label><input type="radio" name="q26" value="b"> B. To reduce foaming when agitated.</label>
-        <label><input type="radio" name="q26" value="c"> C. To distinguish it from engine oil.</label>
-        <label><input type="radio" name="q26" value="d"> D. To enhance oxidation stability.</label>
+        <label><input type="radio" name="q26" value="a">To ensure non-corrosion to metal parts.</label>
+        <label><input type="radio" name="q26" value="b">To reduce foaming when agitated.</label>
+        <label><input type="radio" name="q26" value="c">To distinguish it from engine oil.</label>
+        <label><input type="radio" name="q26" value="d">To enhance oxidation stability.</label>
       </div>
 
 <div class="question">
         <p><strong>ATF Type F is characterized by having which specific property that transmissions requiring it require?</strong></p>
-        <label><input type="radio" name="q27" value="a"> A. Excellent fluidity at low temperatures.</label>
-        <label><input type="radio" name="q27" value="b"> B. A high-frictional coefficient.</label>
-        <label><input type="radio" name="q27" value="c"> C. A low pour point to ensure quiet operation.</label>
-        <label><input type="radio" name="q27" value="d"> D. Seal swell agents for compatibility with modern high-temperature seals.</label>
+        <label><input type="radio" name="q27" value="a">Excellent fluidity at low temperatures.</label>
+        <label><input type="radio" name="q27" value="b">A high-frictional coefficient.</label>
+        <label><input type="radio" name="q27" value="c">A low pour point to ensure quiet operation.</label>
+        <label><input type="radio" name="q27" value="d">Seal swell agents for compatibility with modern high-temperature seals.</label>
       </div>
 
 <div class="question">
         <p><strong>Automatic transmission fluid (ATF) consists of approximately what percentage of base oil and performance additives?</strong></p>
-        <label><input type="radio" name="q28" value="a"> A. 70% base oil and 30% additives.</label>
-        <label><input type="radio" name="q28" value="b"> B. 85 to 90% base oil and 10 to 15% performance additives.</label>
-        <label><input type="radio" name="q28" value="c"> C. 50% base oil and 50% additives.</label>
-        <label><input type="radio" name="q28" value="d"> D. 95% base oil and 5% additives.</label>
+        <label><input type="radio" name="q28" value="a">70% base oil and 30% additives.</label>
+        <label><input type="radio" name="q28" value="b">85 to 90% base oil and 10 to 15% performance additives.</label>
+        <label><input type="radio" name="q28" value="c">50% base oil and 50% additives.</label>
+        <label><input type="radio" name="q28" value="d">95% base oil and 5% additives.</label>
       </div>
 
 <div class="question">
         <p><strong>What is the purpose of the Torque Converter Clutch (TCC) in lockup converters?</strong></p>
-        <label><input type="radio" name="q29" value="a"> A. To multiply torque from the engine at stall speed.</label>
-        <label><input type="radio" name="q29" value="b"> B. To absorb and dampen engine power pulses.</label>
-        <label><input type="radio" name="q29" value="c"> C. To provide direct drive from the engine to the transmission.</label>
-        <label><input type="radio" name="q29" value="d"> D. To provide a no-drive condition at low engine rpm.</label>
+        <label><input type="radio" name="q29" value="a">To multiply torque from the engine at stall speed.</label>
+        <label><input type="radio" name="q29" value="b">To absorb and dampen engine power pulses.</label>
+        <label><input type="radio" name="q29" value="c">To provide direct drive from the engine to the transmission.</label>
+        <label><input type="radio" name="q29" value="d">To provide a no-drive condition at low engine rpm.</label>
       </div>
 
 <div class="question">
         <p><strong>Which major advantage is provided by the lockup torque converter over the conventional non-lockup type?</strong></p>
-        <label><input type="radio" name="q30" value="a"> A. Increased torque multiplication up to 4.00:1.</label>
-        <label><input type="radio" name="q30" value="b"> B. Elimination of slippage (which reduces operational heat and improves fuel economy).</label>
-        <label><input type="radio" name="q30" value="c"> C. Elimination of the need for planetary gear sets.</label>
-        <label><input type="radio" name="q30" value="d"> D. Reduction of hydraulic control system complexity.</label>
+        <label><input type="radio" name="q30" value="a">Increased torque multiplication up to 4.00:1.</label>
+        <label><input type="radio" name="q30" value="b">Elimination of slippage (which reduces operational heat and improves fuel economy).</label>
+        <label><input type="radio" name="q30" value="c">Elimination of the need for planetary gear sets.</label>
+        <label><input type="radio" name="q30" value="d">Reduction of hydraulic control system complexity.</label>
       </div>
 
 <div class="question">
         <p><strong>A lockup converter is known as a four-member (element) converter because it contains the standard three elements plus which additional assembly?</strong></p>
-        <label><input type="radio" name="q31" value="a"> A. A centrifugal weight system.</label>
-        <label><input type="radio" name="q31" value="b"> B. A converter clutch assembly.</label>
-        <label><input type="radio" name="q31" value="c"> C. A permanent stator lock.</label>
-        <label><input type="radio" name="q31" value="d"> D. A split guide ring.</label>
+        <label><input type="radio" name="q31" value="a">A centrifugal weight system.</label>
+        <label><input type="radio" name="q31" value="b">A converter clutch assembly.</label>
+        <label><input type="radio" name="q31" value="c">A permanent stator lock.</label>
+        <label><input type="radio" name="q31" value="d">A split guide ring.</label>
       </div>
 
 <div class="question">
         <p><strong>The apply piston/plate in a lockup converter incorporates what component to reduce torsional vibration when the converter is locked?</strong></p>
-        <label><input type="radio" name="q32" value="a"> A. Belleville springs.</label>
-        <label><input type="radio" name="q32" value="b"> B. Centrifugal weights.</label>
-        <label><input type="radio" name="q32" value="c"> C. Torsion springs.</label>
-        <label><input type="radio" name="q32" value="d"> D. Pinion position shims.</label>
+        <label><input type="radio" name="q32" value="a">Belleville springs.</label>
+        <label><input type="radio" name="q32" value="b">Centrifugal weights.</label>
+        <label><input type="radio" name="q32" value="c">Torsion springs.</label>
+        <label><input type="radio" name="q32" value="d">Pinion position shims.</label>
       </div>
 
 <div class="question">
         <p><strong>How is the process of locking the lockup converter clutch accomplished?</strong></p>
-        <label><input type="radio" name="q33" value="a"> A. By shutting off fluid flow completely to the transmission input shaft.</label>
-        <label><input type="radio" name="q33" value="b"> B. By reversing the oil flow, forcing fluid into the back side of the converter.</label>
-        <label><input type="radio" name="q33" value="c"> C. By utilizing the centrifugal force of the impeller to apply the clutch.</label>
-        <label><input type="radio" name="q33" value="d"> D. By engaging the brake switch, which prevents clutch application.</label>
+        <label><input type="radio" name="q33" value="a">By shutting off fluid flow completely to the transmission input shaft.</label>
+        <label><input type="radio" name="q33" value="b">By reversing the oil flow, forcing fluid into the back side of the converter.</label>
+        <label><input type="radio" name="q33" value="c">By utilizing the centrifugal force of the impeller to apply the clutch.</label>
+        <label><input type="radio" name="q33" value="d">By engaging the brake switch, which prevents clutch application.</label>
       </div>
 
 <div class="question">
         <p><strong>What is the state of fluid flow through a lockup torque converter when the lockup clutch is in its engaged position?</strong></p>
-        <label><input type="radio" name="q34" value="a"> A. Maximum vortex flow.</label>
-        <label><input type="radio" name="q34" value="b"> B. Rotary flow with maximum slippage.</label>
-        <label><input type="radio" name="q34" value="c"> C. Fluid flow stops, and pressure builds to a predetermined value.</label>
-        <label><input type="radio" name="q34" value="d"> D. Fluid flows outward, pushing the apply piston back.</label>
+        <label><input type="radio" name="q34" value="a">Maximum vortex flow.</label>
+        <label><input type="radio" name="q34" value="b">Rotary flow with maximum slippage.</label>
+        <label><input type="radio" name="q34" value="c">Fluid flow stops, and pressure builds to a predetermined value.</label>
+        <label><input type="radio" name="q34" value="d">Fluid flows outward, pushing the apply piston back.</label>
       </div>
 
 <div class="question">
         <p><strong>The lockup clutch in a non-computer controlled vehicle will only engage when the transmission is in which specific gear?</strong></p>
-        <label><input type="radio" name="q35" value="a"> A. Fourth (Overdrive) gear.</label>
-        <label><input type="radio" name="q35" value="b"> B. Third gear.</label>
-        <label><input type="radio" name="q35" value="c"> C. First gear (Reduction).</label>
-        <label><input type="radio" name="q35" value="d"> D. Reverse gear.</label>
+        <label><input type="radio" name="q35" value="a">Fourth (Overdrive) gear.</label>
+        <label><input type="radio" name="q35" value="b">Third gear.</label>
+        <label><input type="radio" name="q35" value="c">First gear (Reduction).</label>
+        <label><input type="radio" name="q35" value="d">Reverse gear.</label>
       </div>
 
 <div class="question">
         <p><strong>In a non-computer controlled vehicle, which condition is one of the ways the locked converter can be unlocked?</strong></p>
-        <label><input type="radio" name="q36" value="a"> A. Accelerating the engine to increase engine vacuum above 3" Hg.</label>
-        <label><input type="radio" name="q36" value="b"> B. Slowing down to below 65 to 40 km/h (40 to 26 mph).</label>
-        <label><input type="radio" name="q36" value="c"> C. The engine coolant temperature drops below 55 ∘C (130 ∘F).</label>
-        <label><input type="radio" name="q36" value="d"> D. Manually shifting into the 4th gear overdrive position.</label>
+        <label><input type="radio" name="q36" value="a">Accelerating the engine to increase engine vacuum above 3" Hg.</label>
+        <label><input type="radio" name="q36" value="b">Slowing down to below 65 to 40 km/h (40 to 26 mph).</label>
+        <label><input type="radio" name="q36" value="c">The engine coolant temperature drops below 55 ∘C (130 ∘F).</label>
+        <label><input type="radio" name="q36" value="d">Manually shifting into the 4th gear overdrive position.</label>
       </div>
 
 <div class="question">
         <p><strong>Which sensor is monitored by the PCM to prevent the torque converter clutch from applying until the engine reaches its operating temperature?</strong></p>
-        <label><input type="radio" name="q37" value="a"> A. Vehicle Speed Sensor (VSS).</label>
-        <label><input type="radio" name="q37" value="b"> B. Throttle Position Sensor (TPS).</label>
-        <label><input type="radio" name="q37" value="c"> C. Coolant Temperature Sensor (ECT).</label>
-        <label><input type="radio" name="q37" value="d"> D. Transmission Oil Temperature Sensor (TOT).</label>
+        <label><input type="radio" name="q37" value="a">Vehicle Speed Sensor (VSS).</label>
+        <label><input type="radio" name="q37" value="b">Throttle Position Sensor (TPS).</label>
+        <label><input type="radio" name="q37" value="c">Coolant Temperature Sensor (ECT).</label>
+        <label><input type="radio" name="q37" value="d">Transmission Oil Temperature Sensor (TOT).</label>
       </div>
 
 <div class="question">
         <p><strong>In the event the Transmission Oil Temperature (TOT) sensor detects an overheat condition, how may the PCM modify the TCC operation?</strong></p>
-        <label><input type="radio" name="q38" value="a"> A. By delaying shift points to reduce gear speed.</label>
-        <label><input type="radio" name="q38" value="b"> B. By increasing the voltage to the brake switch.</label>
-        <label><input type="radio" name="q38" value="c"> C. The torque converter may be locked earlier to eliminate heat build-up.</label>
-        <label><input type="radio" name="q38" value="d"> D. The motor lock circuit is de-energized, applying the lock.</label>
+        <label><input type="radio" name="q38" value="a">By delaying shift points to reduce gear speed.</label>
+        <label><input type="radio" name="q38" value="b">By increasing the voltage to the brake switch.</label>
+        <label><input type="radio" name="q38" value="c">The torque converter may be locked earlier to eliminate heat build-up.</label>
+        <label><input type="radio" name="q38" value="d">The motor lock circuit is de-energized, applying the lock.</label>
       </div>
 
 <div class="question">
         <p><strong>What is the explicit function of the Brake Release Switch signal when received by the PCM?</strong></p>
-        <label><input type="radio" name="q39" value="a"> A. To engage the torque converter lockup clutch immediately.</label>
-        <label><input type="radio" name="q39" value="b"> B. To provide the necessary pressure for the TCC switching valve.</label>
-        <label><input type="radio" name="q39" value="c"> C. To prevent the torque converter clutch from applying.</label>
-        <label><input type="radio" name="q39" value="d"> D. To allow manual downshifting from third gear.</label>
+        <label><input type="radio" name="q39" value="a">To engage the torque converter lockup clutch immediately.</label>
+        <label><input type="radio" name="q39" value="b">To provide the necessary pressure for the TCC switching valve.</label>
+        <label><input type="radio" name="q39" value="c">To prevent the torque converter clutch from applying.</label>
+        <label><input type="radio" name="q39" value="d">To allow manual downshifting from third gear.</label>
       </div>
 
 <div class="question">
         <p><strong>Automatic transmission fluid is defined as a fluid rather than an oil primarily to differentiate it from which other type of lubricant?</strong></p>
-        <label><input type="radio" name="q40" value="a"> A. Gear oil (GL-5).</label>
-        <label><input type="radio" name="q40" value="b"> B. Engine oil.</label>
-        <label><input type="radio" name="q40" value="c"> C. Hydraulic brake fluid.</label>
-        <label><input type="radio" name="q40" value="d"> D. Power steering fluid.</label>
+        <label><input type="radio" name="q40" value="a">Gear oil (GL-5).</label>
+        <label><input type="radio" name="q40" value="b">Engine oil.</label>
+        <label><input type="radio" name="q40" value="c">Hydraulic brake fluid.</label>
+        <label><input type="radio" name="q40" value="d">Power steering fluid.</label>
       </div>
 
 <div class="question">
         <p><strong>Automatic transmission fluids (ATFs) must maintain a high viscosity index to ensure what performance feature is retained?</strong></p>
-        <label><input type="radio" name="q41" value="a"> A. Corrosion control.</label>
-        <label><input type="radio" name="q41" value="b"> B. Seal compatibility.</label>
-        <label><input type="radio" name="q41" value="c"> C. Adequate lubricating film thickness for severe high-temperature service.</label>
-        <label><input type="radio" name="q41" value="d"> D. Controlled volatility.</label>
+        <label><input type="radio" name="q41" value="a">Corrosion control.</label>
+        <label><input type="radio" name="q41" value="b">Seal compatibility.</label>
+        <label><input type="radio" name="q41" value="c">Adequate lubricating film thickness for severe high-temperature service.</label>
+        <label><input type="radio" name="q41" value="d">Controlled volatility.</label>
       </div>
 
 <div class="question">
         <p><strong>What is the general classification of automatic transmission fluids that includes Mercon and Dexron types?</strong></p>
-        <label><input type="radio" name="q42" value="a"> A. Type F.</label>
-        <label><input type="radio" name="q42" value="b"> B. Mercon/Dexron type.</label>
-        <label><input type="radio" name="q42" value="c"> C. Synthetic ATF.</label>
-        <label><input type="radio" name="q42" value="d"> D. High-frictional coefficient type.</label>
+        <label><input type="radio" name="q42" value="a">Type F.</label>
+        <label><input type="radio" name="q42" value="b">Mercon/Dexron type.</label>
+        <label><input type="radio" name="q42" value="c">Synthetic ATF.</label>
+        <label><input type="radio" name="q42" value="d">High-frictional coefficient type.</label>
       </div>
 
 <div class="question">
         <p><strong>Which of the following is considered a Static Seal component of the automatic transmission external components?</strong></p>
-        <label><input type="radio" name="q43" value="a"> A. The extension housing seal.</label>
-        <label><input type="radio" name="q43" value="b"> B. The transmission input shaft seal.</label>
-        <label><input type="radio" name="q43" value="c"> C. The transmission oil pan gasket (seals stationary parts).</label>
-        <label><input type="radio" name="q43" value="d"> D. The torque converter cover seal.</label>
+        <label><input type="radio" name="q43" value="a">The extension housing seal.</label>
+        <label><input type="radio" name="q43" value="b">The transmission input shaft seal.</label>
+        <label><input type="radio" name="q43" value="c">The transmission oil pan gasket (seals stationary parts).</label>
+        <label><input type="radio" name="q43" value="d">The torque converter cover seal.</label>
       </div>
 
 <div class="question">
         <p><strong>What component acts as a reservoir for transmission fluid, houses the transmission filter, and helps cool the fluid by having air flow over it?</strong></p>
-        <label><input type="radio" name="q44" value="a"> A. The bell housing.</label>
-        <label><input type="radio" name="q44" value="b"> B. The transmission case.</label>
-        <label><input type="radio" name="q44" value="c"> C. The transmission oil pan.</label>
-        <label><input type="radio" name="q44" value="d"> D. The extension housing.</label>
+        <label><input type="radio" name="q44" value="a">The bell housing.</label>
+        <label><input type="radio" name="q44" value="b">The transmission case.</label>
+        <label><input type="radio" name="q44" value="c">The transmission oil pan.</label>
+        <label><input type="radio" name="q44" value="d">The extension housing.</label>
       </div>
 
 <div class="question">
         <p><strong>The torque converter hub is the part of the converter housing that supports the rear of the converter. The outer surface of the hub provides a surface for which two transmission components?</strong></p>
-        <label><input type="radio" name="q45" value="a"> A. The flexplate and the ring gear.</label>
-        <label><input type="radio" name="q45" value="b"> B. The transmission front seal and bushing.</label>
-        <label><input type="radio" name="q45" value="c"> C. The governor and the valve body.</label>
-        <label><input type="radio" name="q45" value="d"> D. The stator support and the one-way clutch.</label>
+        <label><input type="radio" name="q45" value="a">The flexplate and the ring gear.</label>
+        <label><input type="radio" name="q45" value="b">The transmission front seal and bushing.</label>
+        <label><input type="radio" name="q45" value="c">The governor and the valve body.</label>
+        <label><input type="radio" name="q45" value="d">The stator support and the one-way clutch.</label>
       </div>
 
 <div class="question">
         <p><strong>When a torque converter fails, which component is listed in Table 2 as a mandatory related sales opportunity?</strong></p>
-        <label><input type="radio" name="q46" value="a"> A. Transmission mounts.</label>
-        <label><input type="radio" name="q46" value="b"> B. Front pump bushing, front pump seal, and fluid.</label>
-        <label><input type="radio" name="q46" value="c"> C. Oil pump O-ring seal.</label>
-        <label><input type="radio" name="q46" value="d"> D. Stator support and stator one-way clutch.</label>
+        <label><input type="radio" name="q46" value="a">Transmission mounts.</label>
+        <label><input type="radio" name="q46" value="b">Front pump bushing, front pump seal, and fluid.</label>
+        <label><input type="radio" name="q46" value="c">Oil pump O-ring seal.</label>
+        <label><input type="radio" name="q46" value="d">Stator support and stator one-way clutch.</label>
       </div>
 
 <div class="question">
         <p><strong>When an oil pump fails, what component is listed in Table 2 as a recommended related sale item?</strong></p>
-        <label><input type="radio" name="q47" value="a"> A. Torque converter drive lugs.</label>
-        <label><input type="radio" name="q47" value="b"> B. Bell housing.</label>
-        <label><input type="radio" name="q47" value="c"> C. Front pump bushing, front pump seal, front pump O-ring seal, and fluid.</label>
-        <label><input type="radio" name="q47" value="d"> D. Governor cover.</label>
+        <label><input type="radio" name="q47" value="a">Torque converter drive lugs.</label>
+        <label><input type="radio" name="q47" value="b">Bell housing.</label>
+        <label><input type="radio" name="q47" value="c">Front pump bushing, front pump seal, front pump O-ring seal, and fluid.</label>
+        <label><input type="radio" name="q47" value="d">Governor cover.</label>
       </div>
 
 <div class="question">
         <p><strong>What is the fundamental disadvantage of manually attempting to restart vortex flow by accelerating the engine after the vehicle has reached approximately 65 to 95 km/h (40 to 60 mph)?</strong></p>
-        <label><input type="radio" name="q48" value="a"> A. The impeller speed will drop below the turbine speed.</label>
-        <label><input type="radio" name="q48" value="b"> B. The stator will permanently lock to the stator support.</label>
-        <label><input type="radio" name="q48" value="c"> C. The average-sized engine is generally not capable of restarting a strong vortex flow at those speeds.</label>
-        <label><input type="radio" name="q48" value="d"> D. The clutch pack will engage automatically, preventing torque multiplication.</label>
+        <label><input type="radio" name="q48" value="a">The impeller speed will drop below the turbine speed.</label>
+        <label><input type="radio" name="q48" value="b">The stator will permanently lock to the stator support.</label>
+        <label><input type="radio" name="q48" value="c">The average-sized engine is generally not capable of restarting a strong vortex flow at those speeds.</label>
+        <label><input type="radio" name="q48" value="d">The clutch pack will engage automatically, preventing torque multiplication.</label>
       </div>
 
 <div class="question">
         <p><strong>What non-transmission input signal is monitored by the PCM to determine the engine load, aiding in the application or release of the torque converter clutch?</strong></p>
-        <label><input type="radio" name="q49" value="a"> A. Coolant Temperature Sensor (ECT).</label>
-        <label><input type="radio" name="q49" value="b"> B. Vacuum Sensor (VS) signal (engine vacuum/load).</label>
-        <label><input type="radio" name="q49" value="c"> C. Vehicle Speed Sensor (VSS).</label>
-        <label><input type="radio" name="q49" value="d"> D. Throttle Position Sensor (TPS).</label>
+        <label><input type="radio" name="q49" value="a">Coolant Temperature Sensor (ECT).</label>
+        <label><input type="radio" name="q49" value="b">Vacuum Sensor (VS) signal (engine vacuum/load).</label>
+        <label><input type="radio" name="q49" value="c">Vehicle Speed Sensor (VSS).</label>
+        <label><input type="radio" name="q49" value="d">Throttle Position Sensor (TPS).</label>
       </div>
 
 <div class="question">
         <p><strong>The greatest volume of oil discharged from the transmission oil pump is delivered to which primary component?</strong></p>
-        <label><input type="radio" name="q50" value="a"> A. The lubrication circuit for the gear set unit.</label>
-        <label><input type="radio" name="q50" value="b"> B. The external oil cooler.</label>
-        <label><input type="radio" name="q50" value="c"> C. The torque converter.</label>
-        <label><input type="radio" name="q50" value="d"> D. The hydraulic control valve system.
+        <label><input type="radio" name="q50" value="a">The lubrication circuit for the gear set unit.</label>
+        <label><input type="radio" name="q50" value="b">The external oil cooler.</label>
+        <label><input type="radio" name="q50" value="c">The torque converter.</label>
+        <label><input type="radio" name="q50" value="d">The hydraulic control valve system.
 Submit Answers</label>
       </div>
 <div class="result-banner" id="result-banner"></div>

--- a/270202-test/270202k - Automatic Transmission Internal Operations.html
+++ b/270202-test/270202k - Automatic Transmission Internal Operations.html
@@ -71,402 +71,402 @@
 
 <div class="question">
   <p><strong>Which gear set is used as the basic means of multiplying the twisting force (torque) from the engine to the driving wheels in the majority of modern automatic transmissions?</strong></p>
-  <label><input type="radio" name="q1" value="a"> A. Helical gear sets</label>
-  <label><input type="radio" name="q1" value="b"> B. Hypoid gear sets</label>
-  <label><input type="radio" name="q1" value="c"> C. Planetary gear sets</label>
-  <label><input type="radio" name="q1" value="d"> D. Worm gear sets</label>
+  <label><input type="radio" name="q1" value="a">Helical gear sets</label>
+  <label><input type="radio" name="q1" value="b">Hypoid gear sets</label>
+  <label><input type="radio" name="q1" value="c">Planetary gear sets</label>
+  <label><input type="radio" name="q1" value="d">Worm gear sets</label>
 </div>
 
 <div class="question">
   <p><strong>To achieve Direct Drive (1:1 ratio) in a simple planetary gear set, which of the following is required according to the laws of operation?</strong></p>
-  <label><input type="radio" name="q2" value="a"> A. The sun gear must be held stationary by a band.</label>
-  <label><input type="radio" name="q2" value="b"> B. The planetary carrier must be used as the input member.</label>
-  <label><input type="radio" name="q2" value="c"> C. Two members must be locked together or driven at the same speed.</label>
-  <label><input type="radio" name="q2" value="d"> D. The ring gear must be freewheeling (overrunning).</label>
+  <label><input type="radio" name="q2" value="a">The sun gear must be held stationary by a band.</label>
+  <label><input type="radio" name="q2" value="b">The planetary carrier must be used as the input member.</label>
+  <label><input type="radio" name="q2" value="c">Two members must be locked together or driven at the same speed.</label>
+  <label><input type="radio" name="q2" value="d">The ring gear must be freewheeling (overrunning).</label>
 </div>
 
 <div class="question">
   <p><strong>To transmit torque through any planetary gear system, regardless of its design, which three operational members must be present?</strong></p>
-  <label><input type="radio" name="q3" value="a"> A. Sun gear, internal/ring gear, and planetary pinions.</label>
-  <label><input type="radio" name="q3" value="b"> B. Drive member, held member, and freewheeling member.</label>
-  <label><input type="radio" name="q3" value="c"> C. One input (drive) member, one output (driven) member, and one reaction (held) member.</label>
-  <label><input type="radio" name="q3" value="d"> D. Planetary carrier, reaction plate, and output shaft.</label>
+  <label><input type="radio" name="q3" value="a">Sun gear, internal/ring gear, and planetary pinions.</label>
+  <label><input type="radio" name="q3" value="b">Drive member, held member, and freewheeling member.</label>
+  <label><input type="radio" name="q3" value="c">One input (drive) member, one output (driven) member, and one reaction (held) member.</label>
+  <label><input type="radio" name="q3" value="d">Planetary carrier, reaction plate, and output shaft.</label>
 </div>
 
 <div class="question">
   <p><strong>A gear set arrangement that uses two simple planetary gear sets mounted on a common sun gear is known as the:</strong></p>
-  <label><input type="radio" name="q4" value="a"> A. Tandem set.</label>
-  <label><input type="radio" name="q4" value="b"> B. Planetary reduction unit.</label>
-  <label><input type="radio" name="q4" value="c"> C. Simpson gear set.</label>
-  <label><input type="radio" name="q4" value="d"> D. Overrunning clutch assembly.</label>
+  <label><input type="radio" name="q4" value="a">Tandem set.</label>
+  <label><input type="radio" name="q4" value="b">Planetary reduction unit.</label>
+  <label><input type="radio" name="q4" value="c">Simpson gear set.</label>
+  <label><input type="radio" name="q4" value="d">Overrunning clutch assembly.</label>
 </div>
 
 <div class="question">
   <p><strong>In a simple planetary gear set, if the Planetary Carrier is held, and the Sun Gear is used as the input member, what is the resulting output combination?</strong></p>
-  <label><input type="radio" name="q5" value="a"> A. Forward Reduction</label>
-  <label><input type="radio" name="q5" value="b"> B. Reverse Overdrive</label>
-  <label><input type="radio" name="q5" value="c"> C. Reverse Reduction</label>
-  <label><input type="radio" name="q5" value="d"> D. Forward Overdrive</label>
+  <label><input type="radio" name="q5" value="a">Forward Reduction</label>
+  <label><input type="radio" name="q5" value="b">Reverse Overdrive</label>
+  <label><input type="radio" name="q5" value="c">Reverse Reduction</label>
+  <label><input type="radio" name="q5" value="d">Forward Overdrive</label>
 </div>
 
 <div class="question">
   <p><strong>If a simple planetary gear set is configured for Forward Deep Reduction, which member is held stationary?</strong></p>
-  <label><input type="radio" name="q6" value="a"> A. Sun Gear</label>
-  <label><input type="radio" name="q6" value="b"> B. Planet Carrier</label>
-  <label><input type="radio" name="q6" value="c"> C. Internal/Ring Gear</label>
-  <label><input type="radio" name="q6" value="d"> D. Input Shaft</label>
+  <label><input type="radio" name="q6" value="a">Sun Gear</label>
+  <label><input type="radio" name="q6" value="b">Planet Carrier</label>
+  <label><input type="radio" name="q6" value="c">Internal/Ring Gear</label>
+  <label><input type="radio" name="q6" value="d">Input Shaft</label>
 </div>
 
 <div class="question">
   <p><strong>To achieve Forward Long Overdrive in a simple planetary gear set, the Internal/Ring Gear is held stationary. Which member must serve as the input member?</strong></p>
-  <label><input type="radio" name="q7" value="a"> A. Sun Gear</label>
-  <label><input type="radio" name="q7" value="b"> B. Planet Carrier</label>
-  <label><input type="radio" name="q7" value="c"> C. Input Shaft</label>
-  <label><input type="radio" name="q7" value="d"> D. Output Shaft</label>
+  <label><input type="radio" name="q7" value="a">Sun Gear</label>
+  <label><input type="radio" name="q7" value="b">Planet Carrier</label>
+  <label><input type="radio" name="q7" value="c">Input Shaft</label>
+  <label><input type="radio" name="q7" value="d">Output Shaft</label>
 </div>
 
 <div class="question">
   <p><strong>In a simple planetary gear set, if the Sun Gear is held stationary and the Internal/Ring Gear is used as the input member, which member serves as the output, providing Forward Reduction?</strong></p>
-  <label><input type="radio" name="q8" value="a"> A. Sun Gear Shaft</label>
-  <label><input type="radio" name="q8" value="b"> B. Rear Internal Gear</label>
-  <label><input type="radio" name="q8" value="c"> C. Planet Carrier</label>
-  <label><input type="radio" name="q8" value="d"> D. Output Shaft</label>
+  <label><input type="radio" name="q8" value="a">Sun Gear Shaft</label>
+  <label><input type="radio" name="q8" value="b">Rear Internal Gear</label>
+  <label><input type="radio" name="q8" value="c">Planet Carrier</label>
+  <label><input type="radio" name="q8" value="d">Output Shaft</label>
 </div>
 
 <div class="question">
   <p><strong>What is the resulting operational condition in a simple planetary gear set if there is no held member and no drive member?</strong></p>
-  <label><input type="radio" name="q9" value="a"> A. Direct Drive</label>
-  <label><input type="radio" name="q9" value="b"> B. Forward Deep Reduction</label>
-  <label><input type="radio" name="q9" value="c"> C. Neutral</label>
-  <label><input type="radio" name="q9" value="d"> D. Reverse Reduction</label>
+  <label><input type="radio" name="q9" value="a">Direct Drive</label>
+  <label><input type="radio" name="q9" value="b">Forward Deep Reduction</label>
+  <label><input type="radio" name="q9" value="c">Neutral</label>
+  <label><input type="radio" name="q9" value="d">Reverse Reduction</label>
 </div>
 
 <div class="question">
   <p><strong>If the Planet Carrier is held stationary and the Ring Gear is used as the input, what member provides the output for Reverse Overdrive?</strong></p>
-  <label><input type="radio" name="q10" value="a"> A. Planetary Pinions</label>
-  <label><input type="radio" name="q10" value="b"> B. Sun Gear</label>
-  <label><input type="radio" name="q10" value="c"> C. Output Shaft</label>
-  <label><input type="radio" name="q10" value="d"> D. Input Shaft</label>
+  <label><input type="radio" name="q10" value="a">Planetary Pinions</label>
+  <label><input type="radio" name="q10" value="b">Sun Gear</label>
+  <label><input type="radio" name="q10" value="c">Output Shaft</label>
+  <label><input type="radio" name="q10" value="d">Input Shaft</label>
 </div>
 
 <div class="question">
   <p><strong>Planetary gear sets are designed to handle large torque loads for their size primarily because of what characteristic?</strong></p>
-  <label><input type="radio" name="q11" value="a"> A. They use spur gears to reduce end thrust.</label>
-  <label><input type="radio" name="q11" value="b"> B. The torque load is distributed over several planet pinion gears, providing more teeth in contact.</label>
-  <label><input type="radio" name="q11" value="c"> C. They utilize a double-acting servo to apply the clutch.</label>
-  <label><input type="radio" name="q11" value="d"> D. They operate exclusively in a locked 1:1 ratio.</label>
+  <label><input type="radio" name="q11" value="a">They use spur gears to reduce end thrust.</label>
+  <label><input type="radio" name="q11" value="b">The torque load is distributed over several planet pinion gears, providing more teeth in contact.</label>
+  <label><input type="radio" name="q11" value="c">They utilize a double-acting servo to apply the clutch.</label>
+  <label><input type="radio" name="q11" value="d">They operate exclusively in a locked 1:1 ratio.</label>
 </div>
 
 <div class="question">
   <p><strong>The gears in a planetary set are considered to be in constant mesh. What primary benefit does this provide?</strong></p>
-  <label><input type="radio" name="q12" value="a"> A. Enables the use of external tooth gears only.</label>
-  <label><input type="radio" name="q12" value="b"> B. Allows for instantaneous servo application.</label>
-  <label><input type="radio" name="q12" value="c"> C. Helps eliminate gear damage from gear clash when shifting gears.</label>
-  <label><input type="radio" name="q12" value="d"> D. Permits the use of the clutch relief check valve.</label>
+  <label><input type="radio" name="q12" value="a">Enables the use of external tooth gears only.</label>
+  <label><input type="radio" name="q12" value="b">Allows for instantaneous servo application.</label>
+  <label><input type="radio" name="q12" value="c">Helps eliminate gear damage from gear clash when shifting gears.</label>
+  <label><input type="radio" name="q12" value="d">Permits the use of the clutch relief check valve.</label>
 </div>
 
 <div class="question">
   <p><strong>The internal/ring gear is meshed with the planetary pinions. When the external tooth planetary pinions rotate inside the internal tooth ring gear, how do they rotate relative to each other?</strong></p>
-  <label><input type="radio" name="q13" value="a"> A. In opposite directions.</label>
-  <label><input type="radio" name="q13" value="b"> B. Only during deep reduction.</label>
-  <label><input type="radio" name="q13" value="c"> C. In the same direction.</label>
-  <label><input type="radio" name="q13" value="d"> D. They do not rotate; they are locked together.</label>
+  <label><input type="radio" name="q13" value="a">In opposite directions.</label>
+  <label><input type="radio" name="q13" value="b">Only during deep reduction.</label>
+  <label><input type="radio" name="q13" value="c">In the same direction.</label>
+  <label><input type="radio" name="q13" value="d">They do not rotate; they are locked together.</label>
 </div>
 
 <div class="question">
   <p><strong>What operational state is achieved in a simple planetary gear set when the Sun Gear is held stationary, and the Planet Carrier is the input member?</strong></p>
-  <label><input type="radio" name="q14" value="a"> A. Reverse Reduction</label>
-  <label><input type="radio" name="q14" value="b"> B. Forward Overdrive</label>
-  <label><input type="radio" name="q14" value="c"> C. Forward Deep Reduction</label>
-  <label><input type="radio" name="q14" value="d"> D. Direct Drive</label>
+  <label><input type="radio" name="q14" value="a">Reverse Reduction</label>
+  <label><input type="radio" name="q14" value="b">Forward Overdrive</label>
+  <label><input type="radio" name="q14" value="c">Forward Deep Reduction</label>
+  <label><input type="radio" name="q14" value="d">Direct Drive</label>
 </div>
 
 <div class="question">
   <p><strong>What are the two types of clutches used to control planetary gear train assemblies in an automatic transmission?</strong></p>
-  <label><input type="radio" name="q15" value="a"> A. Clutch brake and centrifugal clutch.</label>
-  <label><input type="radio" name="q15" value="b"> B. Multiple-disc mechanical and overrunning mechanical.</label>
-  <label><input type="radio" name="q15" value="c"> C. Overrunning (one-way) clutches and multiple-disc hydraulic clutches.</label>
-  <label><input type="radio" name="q15" value="d"> D. Single-wrap and double-wrap clutch bands.</label>
+  <label><input type="radio" name="q15" value="a">Clutch brake and centrifugal clutch.</label>
+  <label><input type="radio" name="q15" value="b">Multiple-disc mechanical and overrunning mechanical.</label>
+  <label><input type="radio" name="q15" value="c">Overrunning (one-way) clutches and multiple-disc hydraulic clutches.</label>
+  <label><input type="radio" name="q15" value="d">Single-wrap and double-wrap clutch bands.</label>
 </div>
 
 <div class="question">
   <p><strong>Which type of clutch is referred to as a wet-type clutch because it operates in automatic transmission fluid?</strong></p>
-  <label><input type="radio" name="q16" value="a"> A. Overrunning clutch</label>
-  <label><input type="radio" name="q16" value="b"> B. Sprag clutch</label>
-  <label><input type="radio" name="q16" value="c"> C. Multiple-disc hydraulic clutch assembly</label>
-  <label><input type="radio" name="q16" value="d"> D. Mechanical clutch brake</label>
+  <label><input type="radio" name="q16" value="a">Overrunning clutch</label>
+  <label><input type="radio" name="q16" value="b">Sprag clutch</label>
+  <label><input type="radio" name="q16" value="c">Multiple-disc hydraulic clutch assembly</label>
+  <label><input type="radio" name="q16" value="d">Mechanical clutch brake</label>
 </div>
 
 <div class="question">
   <p><strong>Which statement accurately describes the operation of overrunning (one-way) clutches?</strong></p>
-  <label><input type="radio" name="q17" value="a"> A. They require continuous hydraulic controls for holding and freewheeling.</label>
-  <label><input type="radio" name="q17" value="b"> B. They require periodic adjustment to maintain holding capacity.</label>
-  <label><input type="radio" name="q17" value="c"> C. They are mechanically applied and released, which requires no hydraulic controls for their operation.</label>
-  <label><input type="radio" name="q17" value="d"> D. They are used exclusively as a driving member to supply torque input.</label>
+  <label><input type="radio" name="q17" value="a">They require continuous hydraulic controls for holding and freewheeling.</label>
+  <label><input type="radio" name="q17" value="b">They require periodic adjustment to maintain holding capacity.</label>
+  <label><input type="radio" name="q17" value="c">They are mechanically applied and released, which requires no hydraulic controls for their operation.</label>
+  <label><input type="radio" name="q17" value="d">They are used exclusively as a driving member to supply torque input.</label>
 </div>
 
 <div class="question">
   <p><strong>What is the explicit functional purpose of the freewheeling action of a one-way clutch?</strong></p>
-  <label><input type="radio" name="q18" value="a"> A. To hold a member of the planetary gear set to the case.</label>
-  <label><input type="radio" name="q18" value="b"> B. To improve shift quality by eliminating a timing problem during band-to-band or band-to-clutch shifts.</label>
-  <label><input type="radio" name="q18" value="c"> C. To provide a high degree of frictional drag in the overrun mode.</label>
-  <label><input type="radio" name="q18" value="d"> D. To force the clutch relief check ball onto its seat.</label>
+  <label><input type="radio" name="q18" value="a">To hold a member of the planetary gear set to the case.</label>
+  <label><input type="radio" name="q18" value="b">To improve shift quality by eliminating a timing problem during band-to-band or band-to-clutch shifts.</label>
+  <label><input type="radio" name="q18" value="c">To provide a high degree of frictional drag in the overrun mode.</label>
+  <label><input type="radio" name="q18" value="d">To force the clutch relief check ball onto its seat.</label>
 </div>
 
 <div class="question">
   <p><strong>In a multiple-disc clutch assembly, the steel plates are generally splined to which component?</strong></p>
-  <label><input type="radio" name="q19" value="a"> A. The center hub</label>
-  <label><input type="radio" name="q19" value="b"> B. The clutch piston</label>
-  <label><input type="radio" name="q19" value="c"> C. The clutch drum or the transmission case</label>
-  <label><input type="radio" name="q19" value="d"> D. The return spring retainer</label>
+  <label><input type="radio" name="q19" value="a">The center hub</label>
+  <label><input type="radio" name="q19" value="b">The clutch piston</label>
+  <label><input type="radio" name="q19" value="c">The clutch drum or the transmission case</label>
+  <label><input type="radio" name="q19" value="d">The return spring retainer</label>
 </div>
 
 <div class="question">
   <p><strong>What determines the torque capacity or torque-holding capacity of a multiple-disc clutch pack assembly?</strong></p>
-  <label><input type="radio" name="q20" value="a"> A. The pressure of the return spring.</label>
-  <label><input type="radio" name="q20" value="b"> B. The number of contacting surfaces (clutch plates and friction discs).</label>
-  <label><input type="radio" name="q20" value="c"> C. The amount of residual oil in the drum.</label>
-  <label><input type="radio" name="q20" value="d"> D. The amount of applied hydraulic mainline pressure.</label>
+  <label><input type="radio" name="q20" value="a">The pressure of the return spring.</label>
+  <label><input type="radio" name="q20" value="b">The number of contacting surfaces (clutch plates and friction discs).</label>
+  <label><input type="radio" name="q20" value="c">The amount of residual oil in the drum.</label>
+  <label><input type="radio" name="q20" value="d">The amount of applied hydraulic mainline pressure.</label>
 </div>
 
 <div class="question">
   <p><strong>What component is stacked alternately with steel plates to make up a clutch pack?</strong></p>
-  <label><input type="radio" name="q21" value="a"> A. Waved snap rings</label>
-  <label><input type="radio" name="q21" value="b"> B. Composition-faced (friction) plates</label>
-  <label><input type="radio" name="q21" value="c"> C. Reaction plates</label>
-  <label><input type="radio" name="q21" value="d"> D. Belleville springs</label>
+  <label><input type="radio" name="q21" value="a">Waved snap rings</label>
+  <label><input type="radio" name="q21" value="b">Composition-faced (friction) plates</label>
+  <label><input type="radio" name="q21" value="c">Reaction plates</label>
+  <label><input type="radio" name="q21" value="d">Belleville springs</label>
 </div>
 
 <div class="question">
   <p><strong>When a multiple-disc clutch is applied, what component compresses the plates, providing a drive between the drum and hub?</strong></p>
-  <label><input type="radio" name="q22" value="a"> A. The wave plate</label>
-  <label><input type="radio" name="q22" value="b"> B. The return spring</label>
-  <label><input type="radio" name="q22" value="c"> C. The apply piston</label>
-  <label><input type="radio" name="q22" value="d"> D. The snap ring</label>
+  <label><input type="radio" name="q22" value="a">The wave plate</label>
+  <label><input type="radio" name="q22" value="b">The return spring</label>
+  <label><input type="radio" name="q22" value="c">The apply piston</label>
+  <label><input type="radio" name="q22" value="d">The snap ring</label>
 </div>
 
 <div class="question">
   <p><strong>Some clutches use a waved steel plate in the clutch pack. What is the specific function of this plate?</strong></p>
-  <label><input type="radio" name="q23" value="a"> A. To secure the friction plates to the hub.</label>
-  <label><input type="radio" name="q23" value="b"> B. To act as a cushioning device.</label>
-  <label><input type="radio" name="q23" value="c"> C. To lock the clutch drum to the case.</label>
-  <label><input type="radio" name="q23" value="d"> D. To transfer power from the clutch drum to the input shaft.</label>
+  <label><input type="radio" name="q23" value="a">To secure the friction plates to the hub.</label>
+  <label><input type="radio" name="q23" value="b">To act as a cushioning device.</label>
+  <label><input type="radio" name="q23" value="c">To lock the clutch drum to the case.</label>
+  <label><input type="radio" name="q23" value="d">To transfer power from the clutch drum to the input shaft.</label>
 </div>
 
 <div class="question">
   <p><strong>The friction material used on clutch plates is made of which types of materials?</strong></p>
-  <label><input type="radio" name="q24" value="a"> A. Sintered bronze or aluminum alloy.</label>
-  <label><input type="radio" name="q24" value="b"> B. Semi-metallic or paper cellulose material.</label>
-  <label><input type="radio" name="q24" value="c"> C. Cast iron or Teflon.</label>
-  <label><input type="radio" name="q24" value="d"> D. High-quality forged steel.</label>
+  <label><input type="radio" name="q24" value="a">Sintered bronze or aluminum alloy.</label>
+  <label><input type="radio" name="q24" value="b">Semi-metallic or paper cellulose material.</label>
+  <label><input type="radio" name="q24" value="c">Cast iron or Teflon.</label>
+  <label><input type="radio" name="q24" value="d">High-quality forged steel.</label>
 </div>
 
 <div class="question">
   <p><strong>The clutch friction plates are typically splined on the inner circumference to mesh with splines on which component?</strong></p>
-  <label><input type="radio" name="q25" value="a"> A. The clutch drum or housing.</label>
-  <label><input type="radio" name="q25" value="b"> B. The servo piston.</label>
-  <label><input type="radio" name="q25" value="c"> C. The center hub of the member to which they are attached.</label>
-  <label><input type="radio" name="q25" value="d"> D. The clutch return spring.</label>
+  <label><input type="radio" name="q25" value="a">The clutch drum or housing.</label>
+  <label><input type="radio" name="q25" value="b">The servo piston.</label>
+  <label><input type="radio" name="q25" value="c">The center hub of the member to which they are attached.</label>
+  <label><input type="radio" name="q25" value="d">The clutch return spring.</label>
 </div>
 
 <div class="question">
   <p><strong>Most hydraulic clutches are applied by pressurized fluid and released by what component?</strong></p>
-  <label><input type="radio" name="q26" value="a"> A. An accumulator</label>
-  <label><input type="radio" name="q26" value="b"> B. A spring or springs</label>
-  <label><input type="radio" name="q26" value="c"> C. A pressure regulator valve</label>
-  <label><input type="radio" name="q26" value="d"> D. A shift rail</label>
+  <label><input type="radio" name="q26" value="a">An accumulator</label>
+  <label><input type="radio" name="q26" value="b">A spring or springs</label>
+  <label><input type="radio" name="q26" value="c">A pressure regulator valve</label>
+  <label><input type="radio" name="q26" value="d">A shift rail</label>
 </div>
 
 <div class="question">
   <p><strong>What component prevents oil leakage between the stationary clutch support and a rotating clutch drum when hydraulic pressure is applied?</strong></p>
-  <label><input type="radio" name="q27" value="a"> A. Clutch apply piston</label>
-  <label><input type="radio" name="q27" value="b"> B. Cast iron or Teflon seal rings</label>
-  <label><input type="radio" name="q27" value="c"> C. Friction plates</label>
-  <label><input type="radio" name="q27" value="d"> D. The clutch relief check valve</label>
+  <label><input type="radio" name="q27" value="a">Clutch apply piston</label>
+  <label><input type="radio" name="q27" value="b">Cast iron or Teflon seal rings</label>
+  <label><input type="radio" name="q27" value="c">Friction plates</label>
+  <label><input type="radio" name="q27" value="d">The clutch relief check valve</label>
 </div>
 
 <div class="question">
   <p><strong>Seal rings provide efficient sealing primarily due to a built-in tension or expansion force that ensures what initial condition?</strong></p>
-  <label><input type="radio" name="q28" value="a"> A. The fluid is restricted by the restrictive orifice.</label>
-  <label><input type="radio" name="q28" value="b"> B. Initial contact with the bore.</label>
-  <label><input type="radio" name="q28" value="c"> C. The fluid pressure is equalized on both sides of the clutch.</label>
-  <label><input type="radio" name="q28" value="d"> D. The stator support is locked to the transmission case.</label>
+  <label><input type="radio" name="q28" value="a">The fluid is restricted by the restrictive orifice.</label>
+  <label><input type="radio" name="q28" value="b">Initial contact with the bore.</label>
+  <label><input type="radio" name="q28" value="c">The fluid pressure is equalized on both sides of the clutch.</label>
+  <label><input type="radio" name="q28" value="d">The stator support is locked to the transmission case.</label>
 </div>
 
 <div class="question">
   <p><strong>A Scarf Cut refers to which characteristic of a Teflon seal ring?</strong></p>
-  <label><input type="radio" name="q29" value="a"> A. A coarse finish on the edge left from manufacturing.</label>
-  <label><input type="radio" name="q29" value="b"> B. The ends are cut on an angle.</label>
-  <label><input type="radio" name="q29" value="c"> C. A square-cut end on a cast iron seal.</label>
-  <label><input type="radio" name="q29" value="d"> D. A one-piece rubber seal design.</label>
+  <label><input type="radio" name="q29" value="a">A coarse finish on the edge left from manufacturing.</label>
+  <label><input type="radio" name="q29" value="b">The ends are cut on an angle.</label>
+  <label><input type="radio" name="q29" value="c">A square-cut end on a cast iron seal.</label>
+  <label><input type="radio" name="q29" value="d">A one-piece rubber seal design.</label>
 </div>
 
 <div class="question">
   <p><strong>Cast iron seal rings are distinguished by always having an opening, which may be secured by which two types of ends?</strong></p>
-  <label><input type="radio" name="q30" value="a"> A. One-piece or lathe-cut.</label>
-  <label><input type="radio" name="q30" value="b"> B. Square-cut (butt joint) or interlocking hooks.</label>
-  <label><input type="radio" name="q30" value="c"> C. Round O-ring or D-cut O-ring.</label>
-  <label><input type="radio" name="q30" value="d"> D. Rubber or neoprene.</label>
+  <label><input type="radio" name="q30" value="a">One-piece or lathe-cut.</label>
+  <label><input type="radio" name="q30" value="b">Square-cut (butt joint) or interlocking hooks.</label>
+  <label><input type="radio" name="q30" value="c">Round O-ring or D-cut O-ring.</label>
+  <label><input type="radio" name="q30" value="d">Rubber or neoprene.</label>
 </div>
 
 <div class="question">
   <p><strong>Lathe-cut seals are always one-piece seals made of neoprene or Viton. What unique feature of their edge aids in providing a tight seal?</strong></p>
-  <label><input type="radio" name="q31" value="a"> A. The interlocking hooked ends.</label>
-  <label><input type="radio" name="q31" value="b"> B. The ability to freewheel in the overrun mode.</label>
-  <label><input type="radio" name="q31" value="c"> C. A coarse finish left over from the manufacturing process.</label>
-  <label><input type="radio" name="q31" value="d"> D. A special spring retainer that compresses the rubber.</label>
+  <label><input type="radio" name="q31" value="a">The interlocking hooked ends.</label>
+  <label><input type="radio" name="q31" value="b">The ability to freewheel in the overrun mode.</label>
+  <label><input type="radio" name="q31" value="c">A coarse finish left over from the manufacturing process.</label>
+  <label><input type="radio" name="q31" value="d">A special spring retainer that compresses the rubber.</label>
 </div>
 
 <div class="question">
   <p><strong>The clutch drum, which houses the complete clutch assembly, may be made of which three materials?</strong></p>
-  <label><input type="radio" name="q32" value="a"> A. Steel plate, neoprene, or Teflon.</label>
-  <label><input type="radio" name="q32" value="b"> B. Cast iron, aluminum, or lightweight stamped steel.</label>
-  <label><input type="radio" name="q32" value="c"> C. Brass, bronze, or copper.</label>
-  <label><input type="radio" name="q32" value="d"> D. Steel strap, Belleville spring steel, or cast iron band material.</label>
+  <label><input type="radio" name="q32" value="a">Steel plate, neoprene, or Teflon.</label>
+  <label><input type="radio" name="q32" value="b">Cast iron, aluminum, or lightweight stamped steel.</label>
+  <label><input type="radio" name="q32" value="c">Brass, bronze, or copper.</label>
+  <label><input type="radio" name="q32" value="d">Steel strap, Belleville spring steel, or cast iron band material.</label>
 </div>
 
 <div class="question">
   <p><strong>How are clutch pistons applied and released?</strong></p>
-  <label><input type="radio" name="q33" value="a"> A. Applied by spring force and released by centrifugal force.</label>
-  <label><input type="radio" name="q33" value="b"> B. Applied by mainline oil pressure and released by a spring or springs.</label>
-  <label><input type="radio" name="q33" value="c"> C. Applied by an accumulator and released by a servo piston.</label>
-  <label><input type="radio" name="q33" value="d"> D. Applied by centrifugal force and released by the brake switch.</label>
+  <label><input type="radio" name="q33" value="a">Applied by spring force and released by centrifugal force.</label>
+  <label><input type="radio" name="q33" value="b">Applied by mainline oil pressure and released by a spring or springs.</label>
+  <label><input type="radio" name="q33" value="c">Applied by an accumulator and released by a servo piston.</label>
+  <label><input type="radio" name="q33" value="d">Applied by centrifugal force and released by the brake switch.</label>
 </div>
 
 <div class="question">
   <p><strong>A single Belleville type return spring provides an additional purpose besides returning the piston. What is this purpose?</strong></p>
-  <label><input type="radio" name="q34" value="a"> A. To accommodate the short stroking distance required to apply the clutch.</label>
-  <label><input type="radio" name="q34" value="b"> B. To eliminate the need for a pressure plate.</label>
-  <label><input type="radio" name="q34" value="c"> C. It provides a mechanical advantage lever system for applying the clutch.</label>
-  <label><input type="radio" name="q34" value="d"> D. It acts as a stationary anchor point for the clutch drum.</label>
+  <label><input type="radio" name="q34" value="a">To accommodate the short stroking distance required to apply the clutch.</label>
+  <label><input type="radio" name="q34" value="b">To eliminate the need for a pressure plate.</label>
+  <label><input type="radio" name="q34" value="c">It provides a mechanical advantage lever system for applying the clutch.</label>
+  <label><input type="radio" name="q34" value="d">It acts as a stationary anchor point for the clutch drum.</label>
 </div>
 
 <div class="question">
   <p><strong>What is the function of the small steel ball-type check valve found in some clutch pistons or drums?</strong></p>
-  <label><input type="radio" name="q35" value="a"> A. To restrict fluid flow to the clutch plates.</label>
-  <label><input type="radio" name="q35" value="b"> B. To lock the clutch drum to the transmission case.</label>
-  <label><input type="radio" name="q35" value="c"> C. To allow residual oil to escape when the clutch is released and turning at high RPM.</label>
-  <label><input type="radio" name="q35" value="d"> D. To force the apply piston back into its shallow bore.</label>
+  <label><input type="radio" name="q35" value="a">To restrict fluid flow to the clutch plates.</label>
+  <label><input type="radio" name="q35" value="b">To lock the clutch drum to the transmission case.</label>
+  <label><input type="radio" name="q35" value="c">To allow residual oil to escape when the clutch is released and turning at high RPM.</label>
+  <label><input type="radio" name="q35" value="d">To force the apply piston back into its shallow bore.</label>
 </div>
 
 <div class="question">
   <p><strong>Without the clutch relief check valve, why might the clutch become partially applied during high RPM rotation when released?</strong></p>
-  <label><input type="radio" name="q36" value="a"> A. The accumulator would fail to cushion the shift.</label>
-  <label><input type="radio" name="q36" value="b"> B. Residual oil would be forced outward by the centrifugal force of the rotating clutch.</label>
-  <label><input type="radio" name="q36" value="c"> C. The mainline oil pressure would override the return spring force.</label>
-  <label><input type="radio" name="q36" value="d"> D. The servo piston would be forced into the released position.</label>
+  <label><input type="radio" name="q36" value="a">The accumulator would fail to cushion the shift.</label>
+  <label><input type="radio" name="q36" value="b">Residual oil would be forced outward by the centrifugal force of the rotating clutch.</label>
+  <label><input type="radio" name="q36" value="c">The mainline oil pressure would override the return spring force.</label>
+  <label><input type="radio" name="q36" value="d">The servo piston would be forced into the released position.</label>
 </div>
 
 <div class="question">
   <p><strong>Which of the following is NOT listed as a device used to smooth the engagement (cushion the shock) of clutch assemblies?</strong></p>
-  <label><input type="radio" name="q37" value="a"> A. Waved snap rings</label>
-  <label><input type="radio" name="q37" value="b"> B. Rubber cushion ring</label>
-  <label><input type="radio" name="q37" value="c"> C. Accumulator</label>
-  <label><input type="radio" name="q37" value="d"> D. Torsional dampeners</label>
+  <label><input type="radio" name="q37" value="a">Waved snap rings</label>
+  <label><input type="radio" name="q37" value="b">Rubber cushion ring</label>
+  <label><input type="radio" name="q37" value="c">Accumulator</label>
+  <label><input type="radio" name="q37" value="d">Torsional dampeners</label>
 </div>
 
 <div class="question">
   <p><strong>How does a waved snap ring help eliminate some of the harshness of a clutch apply?</strong></p>
-  <label><input type="radio" name="q38" value="a"> A. It acts as a pressure regulator to reduce mainline pressure.</label>
-  <label><input type="radio" name="q38" value="b"> B. Its straightening or flattening action is compressed flat, allowing full pressure to build within the clutch.</label>
-  <label><input type="radio" name="q38" value="c"> C. It allows for the controlled escape of oil and vapour during engagement.</label>
-  <label><input type="radio" name="q38" value="d"> D. It forces the clutch drum to align with the center hub.</label>
+  <label><input type="radio" name="q38" value="a">It acts as a pressure regulator to reduce mainline pressure.</label>
+  <label><input type="radio" name="q38" value="b">Its straightening or flattening action is compressed flat, allowing full pressure to build within the clutch.</label>
+  <label><input type="radio" name="q38" value="c">It allows for the controlled escape of oil and vapour during engagement.</label>
+  <label><input type="radio" name="q38" value="d">It forces the clutch drum to align with the center hub.</label>
 </div>
 
 <div class="question">
   <p><strong>An accumulator functions in the clutch apply circuit to control harshness or aggressiveness. How is the accumulator specifically classified relative to the clutch assembly?</strong></p>
-  <label><input type="radio" name="q39" value="a"> A. As a type of clutch piston.</label>
-  <label><input type="radio" name="q39" value="b"> B. As a type of Belleville spring.</label>
-  <label><input type="radio" name="q39" value="c"> C. It is not an integral part of the clutch assembly.</label>
-  <label><input type="radio" name="q39" value="d"> D. As a clutch cushioning device that uses centrifugal force.</label>
+  <label><input type="radio" name="q39" value="a">As a type of clutch piston.</label>
+  <label><input type="radio" name="q39" value="b">As a type of Belleville spring.</label>
+  <label><input type="radio" name="q39" value="c">It is not an integral part of the clutch assembly.</label>
+  <label><input type="radio" name="q39" value="d">As a clutch cushioning device that uses centrifugal force.</label>
 </div>
 
 <div class="question">
   <p><strong>How does a piston type accumulator cushion the application of a clutch?</strong></p>
-  <label><input type="radio" name="q40" value="a"> A. By restricting the flow of oil through a filter mesh.</label>
-  <label><input type="radio" name="q40" value="b"> B. By instantly reversing the oil flow.</label>
-  <label><input type="radio" name="q40" value="c"> C. It absorbs fluid as the piston strokes, making pressure buildup more gradual and clutch engagement smooth.</label>
-  <label><input type="radio" name="q40" value="d"> D. By applying hydraulic pressure directly against the return spring.</label>
+  <label><input type="radio" name="q40" value="a">By restricting the flow of oil through a filter mesh.</label>
+  <label><input type="radio" name="q40" value="b">By instantly reversing the oil flow.</label>
+  <label><input type="radio" name="q40" value="c">It absorbs fluid as the piston strokes, making pressure buildup more gradual and clutch engagement smooth.</label>
+  <label><input type="radio" name="q40" value="d">By applying hydraulic pressure directly against the return spring.</label>
 </div>
 
 <div class="question">
   <p><strong>What is the fundamental role of a transmission band?</strong></p>
-  <label><input type="radio" name="q41" value="a"> A. To provide driving torque to the planetary gear set.</label>
-  <label><input type="radio" name="q41" value="b"> B. To act as a flexible contracting brake assembly that is always used as a holding (reaction) member.</label>
-  <label><input type="radio" name="q41" value="c"> C. To provide a permanent 1:1 ratio once the coupling point is reached.</label>
-  <label><input type="radio" name="q41" value="d"> D. To equalize the speed difference between two planetary members.</label>
+  <label><input type="radio" name="q41" value="a">To provide driving torque to the planetary gear set.</label>
+  <label><input type="radio" name="q41" value="b">To act as a flexible contracting brake assembly that is always used as a holding (reaction) member.</label>
+  <label><input type="radio" name="q41" value="c">To provide a permanent 1:1 ratio once the coupling point is reached.</label>
+  <label><input type="radio" name="q41" value="d">To equalize the speed difference between two planetary members.</label>
 </div>
 
 <div class="question">
   <p><strong>What characteristics of a transmission band primarily determine its holding ability?</strong></p>
-  <label><input type="radio" name="q42" value="a"> A. The diameter of the drum it surrounds and the coefficient of friction.</label>
-  <label><input type="radio" name="q42" value="b"> B. The length and width of the band and the amount of force applied against the band's anchored end.</label>
-  <label><input type="radio" name="q42" value="c"> C. The thickness of the band and the frequency of adjustment.</label>
-  <label><input type="radio" name="q42" value="d"> D. The material of the clutch drum (cast iron or aluminum).</label>
+  <label><input type="radio" name="q42" value="a">The diameter of the drum it surrounds and the coefficient of friction.</label>
+  <label><input type="radio" name="q42" value="b">The length and width of the band and the amount of force applied against the band's anchored end.</label>
+  <label><input type="radio" name="q42" value="c">The thickness of the band and the frequency of adjustment.</label>
+  <label><input type="radio" name="q42" value="d">The material of the clutch drum (cast iron or aluminum).</label>
 </div>
 
 <div class="question">
   <p><strong>Which design feature allows the transmission band to be applied with less hydraulic pressure?</strong></p>
-  <label><input type="radio" name="q43" value="a"> A. The use of a double-wrap design only.</label>
-  <label><input type="radio" name="q43" value="b"> B. The self-disengagement characteristic.</label>
-  <label><input type="radio" name="q43" value="c"> C. The apply servo is mounted so that force is applied in the same direction as the drum rotation.</label>
-  <label><input type="radio" name="q43" value="d"> D. The reliance on helical gearing to reduce end thrust.</label>
+  <label><input type="radio" name="q43" value="a">The use of a double-wrap design only.</label>
+  <label><input type="radio" name="q43" value="b">The self-disengagement characteristic.</label>
+  <label><input type="radio" name="q43" value="c">The apply servo is mounted so that force is applied in the same direction as the drum rotation.</label>
+  <label><input type="radio" name="q43" value="d">The reliance on helical gearing to reduce end thrust.</label>
 </div>
 
 <div class="question">
   <p><strong>Which type of band design provides greater holding ability due to the self-energizing or wrap-around action of its connecting segments?</strong></p>
-  <label><input type="radio" name="q44" value="a"> A. Single-wrap band</label>
-  <label><input type="radio" name="q44" value="b"> B. Steel strap band</label>
-  <label><input type="radio" name="q44" value="c"> C. Double-wrap band</label>
-  <label><input type="radio" name="q44" value="d"> D. Cast iron band</label>
+  <label><input type="radio" name="q44" value="a">Single-wrap band</label>
+  <label><input type="radio" name="q44" value="b">Steel strap band</label>
+  <label><input type="radio" name="q44" value="c">Double-wrap band</label>
+  <label><input type="radio" name="q44" value="d">Cast iron band</label>
 </div>
 
 <div class="question">
   <p><strong>The friction lining of a transmission band is either semi-metallic or organic. In most applications, when the band is used to hold a stationary drum (Manual Low (L1) or Reverse (R)), which friction material is used?</strong></p>
-  <label><input type="radio" name="q45" value="a"> A. Organic (paper pulp or cellulose).</label>
-  <label><input type="radio" name="q45" value="b"> B. Semi-metallic material (can withstand high unit pressures).</label>
-  <label><input type="radio" name="q45" value="c"> C. Rubber cushion ring.</label>
-  <label><input type="radio" name="q45" value="d"> D. Teflon or Vitton.</label>
+  <label><input type="radio" name="q45" value="a">Organic (paper pulp or cellulose).</label>
+  <label><input type="radio" name="q45" value="b">Semi-metallic material (can withstand high unit pressures).</label>
+  <label><input type="radio" name="q45" value="c">Rubber cushion ring.</label>
+  <label><input type="radio" name="q45" value="d">Teflon or Vitton.</label>
 </div>
 
 <div class="question">
   <p><strong>What component is a hydraulically operated piston used to convert hydraulic pressure into mechanical force to apply a band within a transmission?</strong></p>
-  <label><input type="radio" name="q46" value="a"> A. An accumulator</label>
-  <label><input type="radio" name="q46" value="b"> B. A check valve</label>
-  <label><input type="radio" name="q46" value="c"> C. A servo assembly</label>
-  <label><input type="radio" name="q46" value="d"> D. A detent pin</label>
+  <label><input type="radio" name="q46" value="a">An accumulator</label>
+  <label><input type="radio" name="q46" value="b">A check valve</label>
+  <label><input type="radio" name="q46" value="c">A servo assembly</label>
+  <label><input type="radio" name="q46" value="d">A detent pin</label>
 </div>
 
 <div class="question">
   <p><strong>Single-acting servos (simple servo design) are generally used for which applications?</strong></p>
-  <label><input type="radio" name="q47" value="a"> A. Those that involve a timed band release during upshifts.</label>
-  <label><input type="radio" name="q47" value="b"> B. Those that require a very large mechanical advantage.</label>
-  <label><input type="radio" name="q47" value="c"> C. Applications that do not involve automatic upshifts or timed band releases, such as Manual Low (ML) or Reverse (R).</label>
-  <label><input type="radio" name="q47" value="d"> D. Applications requiring the servo to also act as an accumulator.</label>
+  <label><input type="radio" name="q47" value="a">Those that involve a timed band release during upshifts.</label>
+  <label><input type="radio" name="q47" value="b">Those that require a very large mechanical advantage.</label>
+  <label><input type="radio" name="q47" value="c">Applications that do not involve automatic upshifts or timed band releases, such as Manual Low (ML) or Reverse (R).</label>
+  <label><input type="radio" name="q47" value="d">Applications requiring the servo to also act as an accumulator.</label>
 </div>
 
 <div class="question">
   <p><strong>A Double-Acting Servo (Compound Servo Design) releases the band when hydraulic pressure is sent to the release side (spring side) of the piston. What is the state of the apply pressure during this release?</strong></p>
-  <label><input type="radio" name="q48" value="a"> A. Apply pressure is shut off completely.</label>
-  <label><input type="radio" name="q48" value="b"> B. Apply pressure remains on the apply side of the servo piston.</label>
-  <label><input type="radio" name="q48" value="c"> C. Release pressure is less than the apply pressure.</label>
-  <label><input type="radio" name="q48" value="d"> D. The servo coil spring forces the piston to stroke forward.</label>
+  <label><input type="radio" name="q48" value="a">Apply pressure is shut off completely.</label>
+  <label><input type="radio" name="q48" value="b">Apply pressure remains on the apply side of the servo piston.</label>
+  <label><input type="radio" name="q48" value="c">Release pressure is less than the apply pressure.</label>
+  <label><input type="radio" name="q48" value="d">The servo coil spring forces the piston to stroke forward.</label>
 </div>
 
 <div class="question">
   <p><strong>What is the classification of clutch plates listed as a common replacement component when a clutch assembly fails?</strong></p>
-  <label><input type="radio" name="q49" value="a"> A. Waved steel plates</label>
-  <label><input type="radio" name="q49" value="b"> B. Clutch plates</label>
-  <label><input type="radio" name="q49" value="c"> C. Thrust bearings</label>
-  <label><input type="radio" name="q49" value="d"> D. Planetary gear set</label>
+  <label><input type="radio" name="q49" value="a">Waved steel plates</label>
+  <label><input type="radio" name="q49" value="b">Clutch plates</label>
+  <label><input type="radio" name="q49" value="c">Thrust bearings</label>
+  <label><input type="radio" name="q49" value="d">Planetary gear set</label>
 </div>
 
 <div class="question">
   <p><strong>When a band fails, which component is listed as a related sales item?</strong></p>
-  <label><input type="radio" name="q50" value="a"> A. Clutch plates</label>
-  <label><input type="radio" name="q50" value="b"> B. Seals</label>
-  <label><input type="radio" name="q50" value="c"> C. Transmission filter</label>
-  <label><input type="radio" name="q50" value="d"> D. Planetary gear set</label>
+  <label><input type="radio" name="q50" value="a">Clutch plates</label>
+  <label><input type="radio" name="q50" value="b">Seals</label>
+  <label><input type="radio" name="q50" value="c">Transmission filter</label>
+  <label><input type="radio" name="q50" value="d">Planetary gear set</label>
 </div>
 <div class="result-banner" id="result-banner"></div>
 </form>

--- a/270202-test/270202l - Automatic Transmission Hydraulic Components.html
+++ b/270202-test/270202l - Automatic Transmission Hydraulic Components.html
@@ -72,751 +72,751 @@
       <div class="question">
         <p>1. In automatic transmissions, which type of component is used to regulate, direct, and control the pressure and movement of the fluid after it leaves the pump?</p>
         <label>
-          <input type="radio" name="q1" value="a"> A. Oil coolers
+          <input type="radio" name="q1" value="a">Oil coolers
         </label>
         <label>
-          <input type="radio" name="q1" value="b"> B. Accumulators
+          <input type="radio" name="q1" value="b">Accumulators
         </label>
         <label>
-          <input type="radio" name="q1" value="c"> C. Valves and hydraulic passages
+          <input type="radio" name="q1" value="c">Valves and hydraulic passages
         </label>
         <label>
-          <input type="radio" name="q1" value="d"> D. Mechanical linkages
+          <input type="radio" name="q1" value="d">Mechanical linkages
         </label>
       </div>
       <div class="question">
         <p>2. Hydraulic valves in an automatic transmission may be used for which of the following applications?</p>
         <label>
-          <input type="radio" name="q2" value="a"> A. Convert rotary motion to linear motion.
+          <input type="radio" name="q2" value="a">Convert rotary motion to linear motion.
         </label>
         <label>
-          <input type="radio" name="q2" value="b"> B. Prevent excessive engine vacuum.
+          <input type="radio" name="q2" value="b">Prevent excessive engine vacuum.
         </label>
         <label>
-          <input type="radio" name="q2" value="c"> C. Act as a pressure relief to relieve excessive pressure.
+          <input type="radio" name="q2" value="c">Act as a pressure relief to relieve excessive pressure.
         </label>
         <label>
-          <input type="radio" name="q2" value="d"> D. Adjust the crush sleeve on the output shaft.
+          <input type="radio" name="q2" value="d">Adjust the crush sleeve on the output shaft.
         </label>
       </div>
       <div class="question">
         <p>3. What is the primary characteristic of the control valves used in automatic transmissions that directs flow and pressure only?</p>
         <label>
-          <input type="radio" name="q3" value="a"> A. They are complex in design and operation.
+          <input type="radio" name="q3" value="a">They are complex in design and operation.
         </label>
         <label>
-          <input type="radio" name="q3" value="b"> B. They regulate oil pressure and flow.
+          <input type="radio" name="q3" value="b">They regulate oil pressure and flow.
         </label>
         <label>
-          <input type="radio" name="q3" value="c"> C. They are usually very simple in their design and operation.
+          <input type="radio" name="q3" value="c">They are usually very simple in their design and operation.
         </label>
         <label>
-          <input type="radio" name="q3" value="d"> D. They are always balanced valves controlled by engine vacuum.
+          <input type="radio" name="q3" value="d">They are always balanced valves controlled by engine vacuum.
         </label>
       </div>
       <div class="question">
         <p>4. If the oil cooler or cooler lines become restricted or plugged, a spring-loaded ball valve is forced open to allow fluid to bypass the cooler. In this function, the valve acts as what component?</p>
         <label>
-          <input type="radio" name="q4" value="a"> A. A pressure relief valve
+          <input type="radio" name="q4" value="a">A pressure relief valve
         </label>
         <label>
-          <input type="radio" name="q4" value="b"> B. A spool valve
+          <input type="radio" name="q4" value="b">A spool valve
         </label>
         <label>
-          <input type="radio" name="q4" value="c"> C. A bypass valve
+          <input type="radio" name="q4" value="c">A bypass valve
         </label>
         <label>
-          <input type="radio" name="q4" value="d"> D. A simple hydraulic valve
+          <input type="radio" name="q4" value="d">A simple hydraulic valve
         </label>
       </div>
       <div class="question">
         <p>5. What mechanism is commonly used throughout the hydraulic system to dampen the effects of hydraulic pulses?</p>
         <label>
-          <input type="radio" name="q5" value="a"> A. Check valves
+          <input type="radio" name="q5" value="a">Check valves
         </label>
         <label>
-          <input type="radio" name="q5" value="b"> B. Orifices
+          <input type="radio" name="q5" value="b">Orifices
         </label>
         <label>
-          <input type="radio" name="q5" value="c"> C. Spool valve lands
+          <input type="radio" name="q5" value="c">Spool valve lands
         </label>
         <label>
-          <input type="radio" name="q5" value="d"> D. Governor weights
+          <input type="radio" name="q5" value="d">Governor weights
         </label>
       </div>
       <div class="question">
         <p>6. Which component is most commonly used in an automatic transmission when a valve must interconnect several passages or react to more than one pressure?</p>
         <label>
-          <input type="radio" name="q6" value="a"> A. Check valve
+          <input type="radio" name="q6" value="a">Check valve
         </label>
         <label>
-          <input type="radio" name="q6" value="b"> B. Ball-type relief valve
+          <input type="radio" name="q6" value="b">Ball-type relief valve
         </label>
         <label>
-          <input type="radio" name="q6" value="c"> C. Spool valve
+          <input type="radio" name="q6" value="c">Spool valve
         </label>
         <label>
-          <input type="radio" name="q6" value="d"> D. Manual valve
+          <input type="radio" name="q6" value="d">Manual valve
         </label>
       </div>
       <div class="question">
         <p>7. What feature is machined into the lands of a typical spool valve?</p>
         <label>
-          <input type="radio" name="q7" value="a"> A. Exhaust ports
+          <input type="radio" name="q7" value="a">Exhaust ports
         </label>
         <label>
-          <input type="radio" name="q7" value="b"> B. Inlet ports
+          <input type="radio" name="q7" value="b">Inlet ports
         </label>
         <label>
-          <input type="radio" name="q7" value="c"> C. Cleaning grooves
+          <input type="radio" name="q7" value="c">Cleaning grooves
         </label>
         <label>
-          <input type="radio" name="q7" value="d"> D. Valve face
+          <input type="radio" name="q7" value="d">Valve face
         </label>
       </div>
       <div class="question">
         <p>8. Pressure relief valves are primarily used to protect the hydraulic system from damage due to excessive pressure. When the pressure builds beyond the tension of the spring, the valve opens and exhausts the fluid to which location?</p>
         <label>
-          <input type="radio" name="q8" value="a"> A. The oil cooler
+          <input type="radio" name="q8" value="a">The oil cooler
         </label>
         <label>
-          <input type="radio" name="q8" value="b"> B. The governor circuit
+          <input type="radio" name="q8" value="b">The governor circuit
         </label>
         <label>
-          <input type="radio" name="q8" value="c"> C. The sump
+          <input type="radio" name="q8" value="c">The sump
         </label>
         <label>
-          <input type="radio" name="q8" value="d"> D. The manual valve inlet port
+          <input type="radio" name="q8" value="d">The manual valve inlet port
         </label>
       </div>
       <div class="question">
         <p>9. Check valves are classified as one-way valves that simply connect or disconnect hydraulic passages. When is the check valve forced onto its seat to prevent backflow of oil?</p>
         <label>
-          <input type="radio" name="q9" value="a"> A. When fluid is flowing through the inlet passage.
+          <input type="radio" name="q9" value="a">When fluid is flowing through the inlet passage.
         </label>
         <label>
-          <input type="radio" name="q9" value="b"> B. When the pump pressure is at its maximum.
+          <input type="radio" name="q9" value="b">When the pump pressure is at its maximum.
         </label>
         <label>
-          <input type="radio" name="q9" value="c"> C. When fluid pressure is applied to the outlet sides of the valve.
+          <input type="radio" name="q9" value="c">When fluid pressure is applied to the outlet sides of the valve.
         </label>
         <label>
-          <input type="radio" name="q9" value="d"> D. When the pressure relief valve opens.
+          <input type="radio" name="q9" value="d">When the pressure relief valve opens.
         </label>
       </div>
       <div class="question">
         <p>10. The manual valve is unique because its position is determined solely by which type of input?</p>
         <label>
-          <input type="radio" name="q10" value="a"> A. Hydraulic pressure from the governor.
+          <input type="radio" name="q10" value="a">Hydraulic pressure from the governor.
         </label>
         <label>
-          <input type="radio" name="q10" value="b"> B. Vacuum pressure from the modulator.
+          <input type="radio" name="q10" value="b">Vacuum pressure from the modulator.
         </label>
         <label>
-          <input type="radio" name="q10" value="c"> C. Mechanical input from the driver (range selector lever).
+          <input type="radio" name="q10" value="c">Mechanical input from the driver (range selector lever).
         </label>
         <label>
-          <input type="radio" name="q10" value="d"> D. Electrical signal from the PCM.
+          <input type="radio" name="q10" value="d">Electrical signal from the PCM.
         </label>
       </div>
       <div class="question">
         <p>11. What is the specific functional purpose of the manual valve?</p>
         <label>
-          <input type="radio" name="q11" value="a"> A. To regulate mainline pressure based on engine speed.
+          <input type="radio" name="q11" value="a">To regulate mainline pressure based on engine speed.
         </label>
         <label>
-          <input type="radio" name="q11" value="b"> B. To provide a high mainline pressure boost during acceleration.
+          <input type="radio" name="q11" value="b">To provide a high mainline pressure boost during acceleration.
         </label>
         <label>
-          <input type="radio" name="q11" value="c"> C. To direct fluid pressure to the various ports within the hydraulic system to control transmission operation.
+          <input type="radio" name="q11" value="c">To direct fluid pressure to the various ports within the hydraulic system to control transmission operation.
         </label>
         <label>
-          <input type="radio" name="q11" value="d"> D. To convert AC voltage from the VSS into a square wave.
+          <input type="radio" name="q11" value="d">To convert AC voltage from the VSS into a square wave.
         </label>
       </div>
       <div class="question">
         <p>12. The manual valve distributes regulated line pressure to apply the various clutch and band servo assemblies. The fluid pressure is allowed to flow only to which circuits?</p>
         <label>
-          <input type="radio" name="q12" value="a"> A. All ports that are not closed or exhausted.
+          <input type="radio" name="q12" value="a">All ports that are not closed or exhausted.
         </label>
         <label>
-          <input type="radio" name="q12" value="b"> B. The governor valve, throttle valve, and shift valves only.
+          <input type="radio" name="q12" value="b">The governor valve, throttle valve, and shift valves only.
         </label>
         <label>
-          <input type="radio" name="q12" value="c"> C. Only the circuits required for the selected operating range.
+          <input type="radio" name="q12" value="c">Only the circuits required for the selected operating range.
         </label>
         <label>
-          <input type="radio" name="q12" value="d"> D. The mainline pressure boost circuit.
+          <input type="radio" name="q12" value="d">The mainline pressure boost circuit.
         </label>
       </div>
       <div class="question">
         <p>13. What holds the manual valve in each of the operating positions selected by the range selector lever?</p>
         <label>
-          <input type="radio" name="q13" value="a"> A. The hydraulic pressure supplied by the pump.
+          <input type="radio" name="q13" value="a">The hydraulic pressure supplied by the pump.
         </label>
         <label>
-          <input type="radio" name="q13" value="b"> B. A vacuum diaphragm and spring assembly.
+          <input type="radio" name="q13" value="b">A vacuum diaphragm and spring assembly.
         </label>
         <label>
-          <input type="radio" name="q13" value="c"> C. A spring-loaded detent arrangement.
+          <input type="radio" name="q13" value="c">A spring-loaded detent arrangement.
         </label>
         <label>
-          <input type="radio" name="q13" value="d"> D. The overdrive gate stop.
+          <input type="radio" name="q13" value="d">The overdrive gate stop.
         </label>
       </div>
       <div class="question">
         <p>14. What type of valve is the manual valve classified as, based on its internal design?</p>
         <label>
-          <input type="radio" name="q14" value="a"> A. Ball-type relief valve
+          <input type="radio" name="q14" value="a">Ball-type relief valve
         </label>
         <label>
-          <input type="radio" name="q14" value="b"> B. Check valve
+          <input type="radio" name="q14" value="b">Check valve
         </label>
         <label>
-          <input type="radio" name="q14" value="c"> C. Spool valve
+          <input type="radio" name="q14" value="c">Spool valve
         </label>
         <label>
-          <input type="radio" name="q14" value="d"> D. Balanced valve
+          <input type="radio" name="q14" value="d">Balanced valve
         </label>
       </div>
       <div class="question">
         <p>15. In the Park position, what mechanism engages the parking gear (sprag) to lock the output shaft to the case?</p>
         <label>
-          <input type="radio" name="q15" value="a"> A. The overdrive gate stop
+          <input type="radio" name="q15" value="a">The overdrive gate stop
         </label>
         <label>
-          <input type="radio" name="q15" value="b"> B. A park pawl
+          <input type="radio" name="q15" value="b">A park pawl
         </label>
         <label>
-          <input type="radio" name="q15" value="c"> C. The detent arrangement
+          <input type="radio" name="q15" value="c">The detent arrangement
         </label>
         <label>
-          <input type="radio" name="q15" value="d"> D. The shiftgate lever
+          <input type="radio" name="q15" value="d">The shiftgate lever
         </label>
       </div>
       <div class="question">
         <p>16. What is the purpose of the throttle valve (TV) in a transmission hydraulic circuit?</p>
         <label>
-          <input type="radio" name="q16" value="a"> A. To regulate fluid flow to the governor.
+          <input type="radio" name="q16" value="a">To regulate fluid flow to the governor.
         </label>
         <label>
-          <input type="radio" name="q16" value="b"> B. To maintain a constant mainline pressure regardless of engine load.
+          <input type="radio" name="q16" value="b">To maintain a constant mainline pressure regardless of engine load.
         </label>
         <label>
-          <input type="radio" name="q16" value="c"> C. To provide pressure that varies with throttle opening or engine load.
+          <input type="radio" name="q16" value="c">To provide pressure that varies with throttle opening or engine load.
         </label>
         <label>
-          <input type="radio" name="q16" value="d"> D. To act as an on/off switch for the shift solenoids.
+          <input type="radio" name="q16" value="d">To act as an on/off switch for the shift solenoids.
         </label>
       </div>
       <div class="question">
         <p>17. Throttle valves are regulating (balanced) valves that achieve a regulated (balanced) pressure by controlling which specific component of the valve?</p>
         <label>
-          <input type="radio" name="q17" value="a"> A. The exhaust port
+          <input type="radio" name="q17" value="a">The exhaust port
         </label>
         <label>
-          <input type="radio" name="q17" value="b"> B. The inlet port (as the controlling restriction)
+          <input type="radio" name="q17" value="b">The inlet port (as the controlling restriction)
         </label>
         <label>
-          <input type="radio" name="q17" value="c"> C. The overdrive gate stop
+          <input type="radio" name="q17" value="c">The overdrive gate stop
         </label>
         <label>
-          <input type="radio" name="q17" value="d"> D. The spring tension
+          <input type="radio" name="q17" value="d">The spring tension
         </label>
       </div>
       <div class="question">
         <p>18. Throttle (TV) pressure is directed to the boost valve of the main pressure regulator for what primary purpose?</p>
         <label>
-          <input type="radio" name="q18" value="a"> A. To reduce the mainline pressure when the vehicle is stationary.
+          <input type="radio" name="q18" value="a">To reduce the mainline pressure when the vehicle is stationary.
         </label>
         <label>
-          <input type="radio" name="q18" value="b"> B. To boost line pressure and firm upshifts during vehicle acceleration.
+          <input type="radio" name="q18" value="b">To boost line pressure and firm upshifts during vehicle acceleration.
         </label>
         <label>
-          <input type="radio" name="q18" value="c"> C. To close the exhaust port when the valve is in the closed position.
+          <input type="radio" name="q18" value="c">To close the exhaust port when the valve is in the closed position.
         </label>
         <label>
-          <input type="radio" name="q18" value="d"> D. To initiate a downshift (kickdown) for increased economy.
+          <input type="radio" name="q18" value="d">To initiate a downshift (kickdown) for increased economy.
         </label>
       </div>
       <div class="question">
         <p>19. Which condition is NOT a driving situation that requires mainline pressure to be increased above the base value?</p>
         <label>
-          <input type="radio" name="q19" value="a"> A. Engine torque increases due to acceleration.
+          <input type="radio" name="q19" value="a">Engine torque increases due to acceleration.
         </label>
         <label>
-          <input type="radio" name="q19" value="b"> B. Manual ranges for trailer towing or engine braking.
+          <input type="radio" name="q19" value="b">Manual ranges for trailer towing or engine braking.
         </label>
         <label>
-          <input type="radio" name="q19" value="c"> C. Reverse range operation.
+          <input type="radio" name="q19" value="c">Reverse range operation.
         </label>
         <label>
-          <input type="radio" name="q19" value="d"> D. Normal cruising at a constant speed and light throttle.
+          <input type="radio" name="q19" value="d">Normal cruising at a constant speed and light throttle.
         </label>
       </div>
       <div class="question">
         <p>20. When the throttle linkage is moved to the closed throttle position, what is the resulting outlet pressure (TV) directed to the shift valve assemblies?</p>
         <label>
-          <input type="radio" name="q20" value="a"> A. High pressure equal to line pressure.
+          <input type="radio" name="q20" value="a">High pressure equal to line pressure.
         </label>
         <label>
-          <input type="radio" name="q20" value="b"> B. Pressure equivalent to 3 &#x27;&#x27; Hg vacuum.
+          <input type="radio" name="q20" value="b">Pressure equivalent to 3 &#x27;&#x27; Hg vacuum.
         </label>
         <label>
-          <input type="radio" name="q20" value="c"> C. 0 psi (zero TV pressure).
+          <input type="radio" name="q20" value="c">0 psi (zero TV pressure).
         </label>
         <label>
-          <input type="radio" name="q20" value="d"> D. 30 psi, resulting in maximum shift points.
+          <input type="radio" name="q20" value="d">30 psi, resulting in maximum shift points.
         </label>
       </div>
       <div class="question">
         <p>21. Directing zero TV pressure to the shift valve assemblies during closed throttle operation results in what shifting characteristic?</p>
         <label>
-          <input type="radio" name="q21" value="a"> A. Firm and aggressive shifts.
+          <input type="radio" name="q21" value="a">Firm and aggressive shifts.
         </label>
         <label>
-          <input type="radio" name="q21" value="b"> B. Delayed upshifts.
+          <input type="radio" name="q21" value="b">Delayed upshifts.
         </label>
         <label>
-          <input type="radio" name="q21" value="c"> C. Minimum shift points.
+          <input type="radio" name="q21" value="c">Minimum shift points.
         </label>
         <label>
-          <input type="radio" name="q21" value="d"> D. Kickdown for increased acceleration.
+          <input type="radio" name="q21" value="d">Kickdown for increased acceleration.
         </label>
       </div>
       <div class="question">
         <p>22. In a mechanically controlled throttle valve system, when the throttle linkage is moved to Wide Open Throttle (WOT), the high pressure is used to delay upshifts to allow them to correspond with:</p>
         <label>
-          <input type="radio" name="q22" value="a"> A. The vacuum modulator setting.
+          <input type="radio" name="q22" value="a">The vacuum modulator setting.
         </label>
         <label>
-          <input type="radio" name="q22" value="b"> B. The lowest possible line pressure.
+          <input type="radio" name="q22" value="b">The lowest possible line pressure.
         </label>
         <label>
-          <input type="radio" name="q22" value="c"> C. The heavier acceleration.
+          <input type="radio" name="q22" value="c">The heavier acceleration.
         </label>
         <label>
-          <input type="radio" name="q22" value="d"> D. The closed throttle position.
+          <input type="radio" name="q22" value="d">The closed throttle position.
         </label>
       </div>
       <div class="question">
         <p>23. Which term has the same meaning as throttle and performs the same functions for transmission operation?</p>
         <label>
-          <input type="radio" name="q23" value="a"> A. Governor
+          <input type="radio" name="q23" value="a">Governor
         </label>
         <label>
-          <input type="radio" name="q23" value="b"> B. Shift valve
+          <input type="radio" name="q23" value="b">Shift valve
         </label>
         <label>
-          <input type="radio" name="q23" value="c"> C. Modulator
+          <input type="radio" name="q23" value="c">Modulator
         </label>
         <label>
-          <input type="radio" name="q23" value="d"> D. Accumulator
+          <input type="radio" name="q23" value="d">Accumulator
         </label>
       </div>
       <div class="question">
         <p>24. The function of the vacuum modulator is to provide a regulated pressure that varies with what external condition?</p>
         <label>
-          <input type="radio" name="q24" value="a"> A. Atmospheric pressure only.
+          <input type="radio" name="q24" value="a">Atmospheric pressure only.
         </label>
         <label>
-          <input type="radio" name="q24" value="b"> B. Output shaft speed.
+          <input type="radio" name="q24" value="b">Output shaft speed.
         </label>
         <label>
-          <input type="radio" name="q24" value="c"> C. Engine manifold vacuum (engine load).
+          <input type="radio" name="q24" value="c">Engine manifold vacuum (engine load).
         </label>
         <label>
-          <input type="radio" name="q24" value="d"> D. Fluid pressure in the shift valve circuits.
+          <input type="radio" name="q24" value="d">Fluid pressure in the shift valve circuits.
         </label>
       </div>
       <div class="question">
         <p>25. The spring side of the vacuum modulator canister is connected to a vacuum line source. The force of the spring is opposed by which force?</p>
         <label>
-          <input type="radio" name="q25" value="a"> A. Atmospheric pressure acting on the diaphragm.
+          <input type="radio" name="q25" value="a">Atmospheric pressure acting on the diaphragm.
         </label>
         <label>
-          <input type="radio" name="q25" value="b"> B. Mainline pressure acting on the valve face.
+          <input type="radio" name="q25" value="b">Mainline pressure acting on the valve face.
         </label>
         <label>
-          <input type="radio" name="q25" value="c"> C. Engine manifold vacuum acting on the diaphragm (in the sealed chamber).
+          <input type="radio" name="q25" value="c">Engine manifold vacuum acting on the diaphragm (in the sealed chamber).
         </label>
         <label>
-          <input type="radio" name="q25" value="d"> D. Centrifugal force from the governor.
+          <input type="radio" name="q25" value="d">Centrifugal force from the governor.
         </label>
       </div>
       <div class="question">
         <p>26. When engine vacuum is high (closed throttle), the pressure differential moves the diaphragm, allowing the modulator valve to close the inlet port. What is the resulting TV pressure?</p>
         <label>
-          <input type="radio" name="q26" value="a"> A. High pressure equal to incoming line pressure.
+          <input type="radio" name="q26" value="a">High pressure equal to incoming line pressure.
         </label>
         <label>
-          <input type="radio" name="q26" value="b"> B. A minimum pressure very close to 0 psi.
+          <input type="radio" name="q26" value="b">A minimum pressure very close to 0 psi.
         </label>
         <label>
-          <input type="radio" name="q26" value="c"> C. Maximum boost pressure (two to three times the base).
+          <input type="radio" name="q26" value="c">Maximum boost pressure (two to three times the base).
         </label>
         <label>
-          <input type="radio" name="q26" value="d"> D. Pressure equal to the spring&#x27;s maximum effective tension.
+          <input type="radio" name="q26" value="d">Pressure equal to the spring&#x27;s maximum effective tension.
         </label>
       </div>
       <div class="question">
         <p>27. When engine vacuum is low (wide open throttle), the coil spring tension is allowed to move the modulator valve, opening the inlet port. The resulting TV pressure is:</p>
         <label>
-          <input type="radio" name="q27" value="a"> A. Minimum hydraulic output pressure.
+          <input type="radio" name="q27" value="a">Minimum hydraulic output pressure.
         </label>
         <label>
-          <input type="radio" name="q27" value="b"> B. High pressure equal to the incoming line pressure.
+          <input type="radio" name="q27" value="b">High pressure equal to the incoming line pressure.
         </label>
         <label>
-          <input type="radio" name="q27" value="c"> C. 0 psi to provide minimum shift points.
+          <input type="radio" name="q27" value="c">0 psi to provide minimum shift points.
         </label>
         <label>
-          <input type="radio" name="q27" value="d"> D. High effective spring tension only.
+          <input type="radio" name="q27" value="d">High effective spring tension only.
         </label>
       </div>
       <div class="question">
         <p>28. What component is considered a hydraulic speedometer that uses centrifugal force to change mainline pressure and output pressure according to vehicle speed?</p>
         <label>
-          <input type="radio" name="q28" value="a"> A. Throttle valve
+          <input type="radio" name="q28" value="a">Throttle valve
         </label>
         <label>
-          <input type="radio" name="q28" value="b"> B. Modulator
+          <input type="radio" name="q28" value="b">Modulator
         </label>
         <label>
-          <input type="radio" name="q28" value="c"> C. Governor
+          <input type="radio" name="q28" value="c">Governor
         </label>
         <label>
-          <input type="radio" name="q28" value="d"> D. Accumulator
+          <input type="radio" name="q28" value="d">Accumulator
         </label>
       </div>
       <div class="question">
         <p>29. Governors are regulating (balanced) valves that use the centrifugal force acting on a weight to produce a regulated output pressure. This pressure is directly proportional to what measurement?</p>
         <label>
-          <input type="radio" name="q29" value="a"> A. Engine RPM.
+          <input type="radio" name="q29" value="a">Engine RPM.
         </label>
         <label>
-          <input type="radio" name="q29" value="b"> B. The rate of rotation (road or vehicle speed).
+          <input type="radio" name="q29" value="b">The rate of rotation (road or vehicle speed).
         </label>
         <label>
-          <input type="radio" name="q29" value="c"> C. The amount of vacuum in the intake manifold.
+          <input type="radio" name="q29" value="c">The amount of vacuum in the intake manifold.
         </label>
         <label>
-          <input type="radio" name="q29" value="d"> D. The hydraulic-assisted spring force.
+          <input type="radio" name="q29" value="d">The hydraulic-assisted spring force.
         </label>
       </div>
       <div class="question">
         <p>30. As vehicle speed increases, the governor pressure is used to reduce or cut back which other pressure?</p>
         <label>
-          <input type="radio" name="q30" value="a"> A. Throttle pressure
+          <input type="radio" name="q30" value="a">Throttle pressure
         </label>
         <label>
-          <input type="radio" name="q30" value="b"> B. Auxiliary hydraulic force
+          <input type="radio" name="q30" value="b">Auxiliary hydraulic force
         </label>
         <label>
-          <input type="radio" name="q30" value="c"> C. Mainline pressure
+          <input type="radio" name="q30" value="c">Mainline pressure
         </label>
         <label>
-          <input type="radio" name="q30" value="d"> D. Exhaust pressure
+          <input type="radio" name="q30" value="d">Exhaust pressure
         </label>
       </div>
       <div class="question">
         <p>31. When a governor valve is fully open, what is the maximum pressure it can produce?</p>
         <label>
-          <input type="radio" name="q31" value="a"> A. 0 psi
+          <input type="radio" name="q31" value="a">0 psi
         </label>
         <label>
-          <input type="radio" name="q31" value="b"> B. Twice the mainline pressure
+          <input type="radio" name="q31" value="b">Twice the mainline pressure
         </label>
         <label>
-          <input type="radio" name="q31" value="c"> C. Pressures equal to mainline pressure.
+          <input type="radio" name="q31" value="c">Pressures equal to mainline pressure.
         </label>
         <label>
-          <input type="radio" name="q31" value="d"> D. Pressures equal to the throttle pressure.
+          <input type="radio" name="q31" value="d">Pressures equal to the throttle pressure.
         </label>
       </div>
       <div class="question">
         <p>32. What is the advantage of using a two-stage governor in automatic transmissions?</p>
         <label>
-          <input type="radio" name="q32" value="a"> A. It eliminates the need for an accumulator.
+          <input type="radio" name="q32" value="a">It eliminates the need for an accumulator.
         </label>
         <label>
-          <input type="radio" name="q32" value="b"> B. It ensures 1:1 ratio during Direct Drive.
+          <input type="radio" name="q32" value="b">It ensures 1:1 ratio during Direct Drive.
         </label>
         <label>
-          <input type="radio" name="q32" value="c"> C. It is designed to provide proper governor pressure throughout all driving ranges.
+          <input type="radio" name="q32" value="c">It is designed to provide proper governor pressure throughout all driving ranges.
         </label>
         <label>
-          <input type="radio" name="q32" value="d"> D. It eliminates the need for an interlock pin.
+          <input type="radio" name="q32" value="d">It eliminates the need for an interlock pin.
         </label>
       </div>
       <div class="question">
         <p>33. What is the main purpose of governor pressure?</p>
         <label>
-          <input type="radio" name="q33" value="a"> A. To increase line pressure during acceleration (boost).
+          <input type="radio" name="q33" value="a">To increase line pressure during acceleration (boost).
         </label>
         <label>
-          <input type="radio" name="q33" value="b"> B. To lock the torque converter clutch.
+          <input type="radio" name="q33" value="b">To lock the torque converter clutch.
         </label>
         <label>
-          <input type="radio" name="q33" value="c"> C. To control automatic upshifts and downshifts.
+          <input type="radio" name="q33" value="c">To control automatic upshifts and downshifts.
         </label>
         <label>
-          <input type="radio" name="q33" value="d"> D. To hold the park pawl in place.
+          <input type="radio" name="q33" value="d">To hold the park pawl in place.
         </label>
       </div>
       <div class="question">
         <p>34. Governor pressure acts upon the shift valves in conjunction with which other pressure to determine when an upshift or downshift should occur?</p>
         <label>
-          <input type="radio" name="q34" value="a"> A. Mainline pressure
+          <input type="radio" name="q34" value="a">Mainline pressure
         </label>
         <label>
-          <input type="radio" name="q34" value="b"> B. Throttle or modulator pressure
+          <input type="radio" name="q34" value="b">Throttle or modulator pressure
         </label>
         <label>
-          <input type="radio" name="q34" value="c"> C. Accumulator pressure
+          <input type="radio" name="q34" value="c">Accumulator pressure
         </label>
         <label>
-          <input type="radio" name="q34" value="d"> D. Converter clutch pressure
+          <input type="radio" name="q34" value="d">Converter clutch pressure
         </label>
       </div>
       <div class="question">
         <p>35. The movement of the shift valve is controlled by pressures that have been regulated by other valves, meaning the shift valve is NOT a:</p>
         <label>
-          <input type="radio" name="q35" value="a"> A. Spool valve.
+          <input type="radio" name="q35" value="a">Spool valve.
         </label>
         <label>
-          <input type="radio" name="q35" value="b"> B. Switch valve.
+          <input type="radio" name="q35" value="b">Switch valve.
         </label>
         <label>
-          <input type="radio" name="q35" value="c"> C. Regulating (balanced) valve.
+          <input type="radio" name="q35" value="c">Regulating (balanced) valve.
         </label>
         <label>
-          <input type="radio" name="q35" value="d"> D. Hydraulic computer element.
+          <input type="radio" name="q35" value="d">Hydraulic computer element.
         </label>
       </div>
       <div class="question">
         <p>36. Shift valves are referred to as switch valves because they are usually a spool-type valve that acts as a simple:</p>
         <label>
-          <input type="radio" name="q36" value="a"> A. Open/close door.
+          <input type="radio" name="q36" value="a">Open/close door.
         </label>
         <label>
-          <input type="radio" name="q36" value="b"> B. On/off switch for a hydraulic circuit.
+          <input type="radio" name="q36" value="b">On/off switch for a hydraulic circuit.
         </label>
         <label>
-          <input type="radio" name="q36" value="c"> C. Relief valve for excessive pressure.
+          <input type="radio" name="q36" value="c">Relief valve for excessive pressure.
         </label>
         <label>
-          <input type="radio" name="q36" value="d"> D. Bypass valve for the cooler circuit.
+          <input type="radio" name="q36" value="d">Bypass valve for the cooler circuit.
         </label>
       </div>
       <div class="question">
         <p>37. What are the two primary purposes of a shift valve?</p>
         <label>
-          <input type="radio" name="q37" value="a"> A. Increase line pressure and compensate for centrifugal force.
+          <input type="radio" name="q37" value="a">Increase line pressure and compensate for centrifugal force.
         </label>
         <label>
-          <input type="radio" name="q37" value="b"> B. Control upshifting and control downshifting.
+          <input type="radio" name="q37" value="b">Control upshifting and control downshifting.
         </label>
         <label>
-          <input type="radio" name="q37" value="c"> C. Regulate mainline pressure and regulate throttle pressure.
+          <input type="radio" name="q37" value="c">Regulate mainline pressure and regulate throttle pressure.
         </label>
         <label>
-          <input type="radio" name="q37" value="d"> D. Disengage the torque converter and lock the planetary gear set.
+          <input type="radio" name="q37" value="d">Disengage the torque converter and lock the planetary gear set.
         </label>
       </div>
       <div class="question">
         <p>38. The number of shift valves required in a transmission equals:</p>
         <label>
-          <input type="radio" name="q38" value="a"> A. The total number of gears.
+          <input type="radio" name="q38" value="a">The total number of gears.
         </label>
         <label>
-          <input type="radio" name="q38" value="b"> B. One less than the number of speeds the transmission has.
+          <input type="radio" name="q38" value="b">One less than the number of speeds the transmission has.
         </label>
         <label>
-          <input type="radio" name="q38" value="c"> C. The number of clutches and bands combined.
+          <input type="radio" name="q38" value="c">The number of clutches and bands combined.
         </label>
         <label>
-          <input type="radio" name="q38" value="d"> D. The number of planetary gear sets.
+          <input type="radio" name="q38" value="d">The number of planetary gear sets.
         </label>
       </div>
       <div class="question">
         <p>39. In a four-speed transmission, how many shift valves are required, and in what order do they operate?</p>
         <label>
-          <input type="radio" name="q39" value="a"> A. Two shift valves, operating independently.
+          <input type="radio" name="q39" value="a">Two shift valves, operating independently.
         </label>
         <label>
-          <input type="radio" name="q39" value="b"> B. Four shift valves, operating simultaneously.
+          <input type="radio" name="q39" value="b">Four shift valves, operating simultaneously.
         </label>
         <label>
-          <input type="radio" name="q39" value="c"> C. Three shift valves, operating in progressive order (1-2, 2-3, 3-4).
+          <input type="radio" name="q39" value="c">Three shift valves, operating in progressive order (1-2, 2-3, 3-4).
         </label>
         <label>
-          <input type="radio" name="q39" value="d"> D. Five shift valves, including the reverse shift valve.
+          <input type="radio" name="q39" value="d">Five shift valves, including the reverse shift valve.
         </label>
       </div>
       <div class="question">
         <p>40. How is a shift valve classified when it is directing fluid pressure to apply the desired clutch or band?</p>
         <label>
-          <input type="radio" name="q40" value="a"> A. Closed
+          <input type="radio" name="q40" value="a">Closed
         </label>
         <label>
-          <input type="radio" name="q40" value="b"> B. Exhausted
+          <input type="radio" name="q40" value="b">Exhausted
         </label>
         <label>
-          <input type="radio" name="q40" value="c"> C. Open
+          <input type="radio" name="q40" value="c">Open
         </label>
         <label>
-          <input type="radio" name="q40" value="d"> D. Neutral
+          <input type="radio" name="q40" value="d">Neutral
         </label>
       </div>
       <div class="question">
         <p>41. What is the condition known as when the electronic control system to the transmission becomes disabled (solenoids all turned off)?</p>
         <label>
-          <input type="radio" name="q41" value="a"> A. Full-time operation
+          <input type="radio" name="q41" value="a">Full-time operation
         </label>
         <label>
-          <input type="radio" name="q41" value="b"> B. Overdrive operation
+          <input type="radio" name="q41" value="b">Overdrive operation
         </label>
         <label>
-          <input type="radio" name="q41" value="c"> C. Fail-safe or default
+          <input type="radio" name="q41" value="c">Fail-safe or default
         </label>
         <label>
-          <input type="radio" name="q41" value="d"> D. Torque steer condition
+          <input type="radio" name="q41" value="d">Torque steer condition
         </label>
       </div>
       <div class="question">
         <p>42. In the fail-safe mode of an electronic transmission, what is the resulting operational state?</p>
         <label>
-          <input type="radio" name="q42" value="a"> A. The transmission automatically shifts into neutral.
+          <input type="radio" name="q42" value="a">The transmission automatically shifts into neutral.
         </label>
         <label>
-          <input type="radio" name="q42" value="b"> B. The transmission operates in one predetermined range.
+          <input type="radio" name="q42" value="b">The transmission operates in one predetermined range.
         </label>
         <label>
-          <input type="radio" name="q42" value="c"> C. The torque converter clutch is permanently locked.
+          <input type="radio" name="q42" value="c">The torque converter clutch is permanently locked.
         </label>
         <label>
-          <input type="radio" name="q42" value="d"> D. Maximum line pressure is reduced to 0 psi.
+          <input type="radio" name="q42" value="d">Maximum line pressure is reduced to 0 psi.
         </label>
       </div>
       <div class="question">
         <p>43. Which electronic output device is an electronic pressure regulator that performs the same function as the vacuum modulator in hydraulically controlled transmissions?</p>
         <label>
-          <input type="radio" name="q43" value="a"> A. Shift Solenoid (SS)
+          <input type="radio" name="q43" value="a">Shift Solenoid (SS)
         </label>
         <label>
-          <input type="radio" name="q43" value="b"> B. Electronic Pressure Control (EPC) Solenoid (or VEM)
+          <input type="radio" name="q43" value="b">Electronic Pressure Control (EPC) Solenoid (or VEM)
         </label>
         <label>
-          <input type="radio" name="q43" value="c"> C. Torque Converter Clutch (TCC) Solenoid
+          <input type="radio" name="q43" value="c">Torque Converter Clutch (TCC) Solenoid
         </label>
         <label>
-          <input type="radio" name="q43" value="d"> D. Manual Lever Position Sensor (MLPS)
+          <input type="radio" name="q43" value="d">Manual Lever Position Sensor (MLPS)
         </label>
       </div>
       <div class="question">
         <p>44. In an EPC solenoid, the duty cycle and current flow are inversely proportional to what measurement?</p>
         <label>
-          <input type="radio" name="q44" value="a"> A. Vehicle speed
+          <input type="radio" name="q44" value="a">Vehicle speed
         </label>
         <label>
-          <input type="radio" name="q44" value="b"> B. Engine coolant temperature
+          <input type="radio" name="q44" value="b">Engine coolant temperature
         </label>
         <label>
-          <input type="radio" name="q44" value="c"> C. Throttle angle
+          <input type="radio" name="q44" value="c">Throttle angle
         </label>
         <label>
-          <input type="radio" name="q44" value="d"> D. Mainline pressure
+          <input type="radio" name="q44" value="d">Mainline pressure
         </label>
       </div>
       <div class="question">
         <p>45. When the throttle angle increases, what change in the EPC solenoid&#x27;s operation occurs, leading to maximum hydraulic output pressure?</p>
         <label>
-          <input type="radio" name="q45" value="a"> A. Duty cycle is increased, increasing current flow.
+          <input type="radio" name="q45" value="a">Duty cycle is increased, increasing current flow.
         </label>
         <label>
-          <input type="radio" name="q45" value="b"> B. Duty cycle is decreased, decreasing current flow.
+          <input type="radio" name="q45" value="b">Duty cycle is decreased, decreasing current flow.
         </label>
         <label>
-          <input type="radio" name="q45" value="c"> C. The solenoid is energized to the maximum extent.
+          <input type="radio" name="q45" value="c">The solenoid is energized to the maximum extent.
         </label>
         <label>
-          <input type="radio" name="q45" value="d"> D. The solenoid is completely turned off (0.0 amps).
+          <input type="radio" name="q45" value="d">The solenoid is completely turned off (0.0 amps).
         </label>
       </div>
       <div class="question">
         <p>46. If the EPC electrical system fails and current flow is 0.0 amps, what is the resulting hydraulic condition in the transmission?</p>
         <label>
-          <input type="radio" name="q46" value="a"> A. Minimum line pressure (0 psi)
+          <input type="radio" name="q46" value="a">Minimum line pressure (0 psi)
         </label>
         <label>
-          <input type="radio" name="q46" value="b"> B. Throttle pressure equals 0 psi
+          <input type="radio" name="q46" value="b">Throttle pressure equals 0 psi
         </label>
         <label>
-          <input type="radio" name="q46" value="c"> C. Maximum line pressure (default setting)
+          <input type="radio" name="q46" value="c">Maximum line pressure (default setting)
         </label>
         <label>
-          <input type="radio" name="q46" value="d"> D. The valve operates at minimum throttle duty cycle
+          <input type="radio" name="q46" value="d">The valve operates at minimum throttle duty cycle
         </label>
       </div>
       <div class="question">
         <p>47. What is the sole purpose of the brake switch signal in controlling torque converter clutch (TCC) operation?</p>
         <label>
-          <input type="radio" name="q47" value="a"> A. To increase line pressure during braking.
+          <input type="radio" name="q47" value="a">To increase line pressure during braking.
         </label>
         <label>
-          <input type="radio" name="q47" value="b"> B. To disengage the torque converter lockup clutch when the brakes are applied.
+          <input type="radio" name="q47" value="b">To disengage the torque converter lockup clutch when the brakes are applied.
         </label>
         <label>
-          <input type="radio" name="q47" value="c"> C. To apply the clutch brake.
+          <input type="radio" name="q47" value="c">To apply the clutch brake.
         </label>
         <label>
-          <input type="radio" name="q47" value="d"> D. To signal the PCM to delay upshifts.
+          <input type="radio" name="q47" value="d">To signal the PCM to delay upshifts.
         </label>
       </div>
       <div class="question">
         <p>48. The PCM uses the Engine Coolant Temperature (ECT) sensor primarily to control what specific function?</p>
         <label>
-          <input type="radio" name="q48" value="a"> A. Shift timing and shift feel.
+          <input type="radio" name="q48" value="a">Shift timing and shift feel.
         </label>
         <label>
-          <input type="radio" name="q48" value="b"> B. Torque converter operation (application).
+          <input type="radio" name="q48" value="b">Torque converter operation (application).
         </label>
         <label>
-          <input type="radio" name="q48" value="c"> C. Engine idle speed compensation.
+          <input type="radio" name="q48" value="c">Engine idle speed compensation.
         </label>
         <label>
-          <input type="radio" name="q48" value="d"> D. Mainline pressure boost.
+          <input type="radio" name="q48" value="d">Mainline pressure boost.
         </label>
       </div>
       <div class="question">
         <p>49. Which two types of solenoids are used to control transmission operation?</p>
         <label>
-          <input type="radio" name="q49" value="a"> A. Hydraulic and mechanical.
+          <input type="radio" name="q49" value="a">Hydraulic and mechanical.
         </label>
         <label>
-          <input type="radio" name="q49" value="b"> B. On/off and pulse width modulated (PWM).
+          <input type="radio" name="q49" value="b">On/off and pulse width modulated (PWM).
         </label>
         <label>
-          <input type="radio" name="q49" value="c"> C. Single-acting and double-acting.
+          <input type="radio" name="q49" value="c">Single-acting and double-acting.
         </label>
         <label>
-          <input type="radio" name="q49" value="d"> D. Fixed displacement and variable displacement.
+          <input type="radio" name="q49" value="d">Fixed displacement and variable displacement.
         </label>
       </div>
       <div class="question">
         <p>50. If a vacuum modulator is replaced, what related sales item is listed in the replacement components table?</p>
         <label>
-          <input type="radio" name="q50" value="a"> A. Fluid
+          <input type="radio" name="q50" value="a">Fluid
         </label>
         <label>
-          <input type="radio" name="q50" value="b"> B. Filter and gasket kit
+          <input type="radio" name="q50" value="b">Filter and gasket kit
         </label>
         <label>
-          <input type="radio" name="q50" value="c"> C. Vacuum hose
+          <input type="radio" name="q50" value="c">Vacuum hose
         </label>
         <label>
-          <input type="radio" name="q50" value="d"> D. Sensors
+          <input type="radio" name="q50" value="d">Sensors
         </label>
       </div>
 <div class="result-banner" id="result-banner"></div>

--- a/Practice Exam/PTP2_Exam1_270201_Engines.html
+++ b/Practice Exam/PTP2_Exam1_270201_Engines.html
@@ -5,6 +5,7 @@
   <title>270201 - Engines and Related Systems</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="../assets/css/chat.css">
   <!-- Load Firebase config and leaderboard for score submission -->
   <script src="../config/firebase.config.js"></script>
   <script src="../assets/js/leaderboard-firebase.js"></script>
@@ -13,6 +14,8 @@
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
   <script src="../assets/fingerprint-logger.js"></script>
+  <script src="../assets/js/avatar-util.js"></script>
+  <script src="../assets/js/chat.js"></script>
 </head>
 <body>
 
@@ -50,7 +53,7 @@
       </p>
     </section>
 
-    <form id="quiz-form" class="exam-form" data-timer-duration="3000">
+    <form id="quiz-form" class="exam-form">
 
       <div class="question">
         <p><strong>Compared with a four-stroke spark-ignition engine, a two-stroke spark-ignition engine generally:</strong></p>

--- a/Practice Exam/PTP2_Exam2_270202_PowerTrain.html
+++ b/Practice Exam/PTP2_Exam2_270202_PowerTrain.html
@@ -5,6 +5,7 @@
   <title>270202 - Power Train</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="../assets/css/chat.css">
   <!-- Load Firebase config and leaderboard for score submission -->
   <script src="../config/firebase.config.js"></script>
   <script src="../assets/js/leaderboard-firebase.js"></script>
@@ -13,6 +14,8 @@
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
   <script src="../assets/fingerprint-logger.js"></script>
+  <script src="../assets/js/avatar-util.js"></script>
+  <script src="../assets/js/chat.js"></script>
 </head>
 <body>
 
@@ -50,702 +53,702 @@
       </p>
     </section>
 
-    <form id="quiz-form" class="exam-form" data-timer-duration="3000">
+    <form id="quiz-form" class="exam-form">
 
-<p><strong>Question 1:</strong> What is the drive ratio of a drive that has a drive pulley with a diameter of 2 inches and a driven pulley with a diameter of 5.5 inches? Round the answer to two decimal places.</p>
+<p><strong>What is the drive ratio of a drive that has a drive pulley with a diameter of 2 inches and a driven pulley with a diameter of 5.5 inches? Round the answer to two decimal places.</p>
 <label><input name="q1" type="radio" value="a"/> 0.36:1</label>
 <label><input name="q1" type="radio" value="b"/> 1.00:1</label>
 <label><input name="q1" type="radio" value="c"/> 2.75:1</label>
 <label><input name="q1" type="radio" value="d"/> 5.50:1</label>
 </div>
 <div class="question">
-<p><strong>Question 2:</strong> A sprocket with 45 teeth turning at 2800 rpm is driving a sprocket with 28 teeth. Find the rpm of the sprocket with 28 teeth. Round the answer to the nearest whole number.</p>
+<p><strong>A sprocket with 45 teeth turning at 2800 rpm is driving a sprocket with 28 teeth. Find the rpm of the sprocket with 28 teeth. Round the answer to the nearest whole number.</p>
 <label><input name="q2" type="radio" value="a"/> 1740 rpm</label>
 <label><input name="q2" type="radio" value="b"/> 2800 rpm</label>
 <label><input name="q2" type="radio" value="c"/> 4500 rpm</label>
 <label><input name="q2" type="radio" value="d"/> 7080 rpm</label>
 </div>
 <div class="question">
-<p><strong>Question 3:</strong> If roller chain stretch due to wear exceeds what maximum tolerance, must the chain be replaced?</p>
+<p><strong>If roller chain stretch due to wear exceeds what maximum tolerance, must the chain be replaced?</p>
 <label><input name="q3" type="radio" value="a"/> Greater than 1% or 2%</label>
 <label><input name="q3" type="radio" value="b"/> Greater than 1.5% or 2.5%</label>
 <label><input name="q3" type="radio" value="c"/> Greater than 2% or 3%</label>
 <label><input name="q3" type="radio" value="d"/> Greater than 4% or 5%</label>
 </div>
 <div class="question">
-<p><strong>Question 4:</strong> Unlike chain drives, V-belt drives are typically considered unsuitable for which requirement?</p>
+<p><strong>Unlike chain drives, V-belt drives are typically considered unsuitable for which requirement?</p>
 <label><input name="q4" type="radio" value="a"/> Operation in hot environments.</label>
 <label><input name="q4" type="radio" value="b"/> Low horsepower applications.</label>
 <label><input name="q4" type="radio" value="c"/> Positive drive requirements, such as timing.</label>
 <label><input name="q4" type="radio" value="d"/> Applications requiring tensioners to compensate for wear.</label>
 </div>
 <div class="question">
-<p><strong>Question 5:</strong> A simple gear train has a drive gear with 12 teeth and a driven gear with 24 teeth. What is the gear ratio, and what type of operational change is achieved?</p>
+<p><strong>A simple gear train has a drive gear with 12 teeth and a driven gear with 24 teeth. What is the gear ratio, and what type of operational change is achieved?</p>
 <label><input name="q5" type="radio" value="a"/> 0.5:1; Overdrive</label>
 <label><input name="q5" type="radio" value="b"/> 1:1; Direct Drive</label>
 <label><input name="q5" type="radio" value="c"/> 2:1; Reduction</label>
 <label><input name="q5" type="radio" value="d"/> 24:1; Deep Reduction</label>
 </div>
 <div class="question">
-<p><strong>Question 6:</strong> A compound gear train consists of an input pair (18 teeth driving 54 teeth) and a second pair (18 teeth driving 72 teeth). What is the resulting total reduction ratio of the compound gear train?</p>
+<p><strong>A compound gear train consists of an input pair (18 teeth driving 54 teeth) and a second pair (18 teeth driving 72 teeth). What is the resulting total reduction ratio of the compound gear train?</p>
 <label><input name="q6" type="radio" value="a"/> 4:1</label>
 <label><input name="q6" type="radio" value="b"/> 8:1</label>
 <label><input name="q6" type="radio" value="c"/> 12:1</label>
 <label><input name="q6" type="radio" value="d"/> 18:1</label>
 </div>
 <div class="question">
-<p><strong>Question 7:</strong> When a large drive gear with 24 teeth turns at 1000 rpm and drives a small gear with 12 teeth, what is the resulting speed and torque output combination?</p>
+<p><strong>When a large drive gear with 24 teeth turns at 1000 rpm and drives a small gear with 12 teeth, what is the resulting speed and torque output combination?</p>
 <label><input name="q7" type="radio" value="a"/> Speed decreases, torque increases.</label>
 <label><input name="q7" type="radio" value="b"/> Speed and torque remain unchanged.</label>
 <label><input name="q7" type="radio" value="c"/> Speed increases, torque decreases.</label>
 <label><input name="q7" type="radio" value="d"/> Speed increases, torque remains the same.</label>
 </div>
 <div class="question">
-<p><strong>Question 8:</strong> In a gear train consisting of an external drive gear, three external idler gears, and an external driven gear, what is the final rotation of the driven gear relative to the drive gear?</p>
+<p><strong>In a gear train consisting of an external drive gear, three external idler gears, and an external driven gear, what is the final rotation of the driven gear relative to the drive gear?</p>
 <label><input name="q8" type="radio" value="a"/> Opposite direction, because the total number of gears is even.</label>
 <label><input name="q8" type="radio" value="b"/> Opposite direction, because the last two gears always rotate oppositely.</label>
 <label><input name="q8" type="radio" value="c"/> Same direction, because an odd number of gears are in mesh.</label>
 <label><input name="q8" type="radio" value="d"/> The direction cannot be determined without knowing the ratio.</label>
 </div>
 <div class="question">
-<p><strong>Question 9:</strong> Compared to spur gears, single helical gears create axial/thrust loads during operation. What physical components are necessary to control these loads?</p>
+<p><strong>Compared to spur gears, single helical gears create axial/thrust loads during operation. What physical components are necessary to control these loads?</p>
 <label><input name="q9" type="radio" value="a"/> Split guide rings.</label>
 <label><input name="q9" type="radio" value="b"/> Speed sensors.</label>
 <label><input name="q9" type="radio" value="c"/> Thrust washers or bearings.</label>
 <label><input name="q9" type="radio" value="d"/> Non-hunting gear assemblies.</label>
 </div>
 <div class="question">
-<p><strong>Question 10:</strong> Due to the tremendous amount of sliding contact and pressure developed between the teeth, Hypoid gear sets require which specialized lubrication type?</p>
+<p><strong>Due to the tremendous amount of sliding contact and pressure developed between the teeth, Hypoid gear sets require which specialized lubrication type?</p>
 <label><input name="q10" type="radio" value="a"/> Automatic Transmission Fluid (ATF).</label>
 <label><input name="q10" type="radio" value="b"/> Synthetic gear oils (GL-1 rated).</label>
 <label><input name="q10" type="radio" value="c"/> A special extreme pressure (EP) type of lubricant.</label>
 <label><input name="q10" type="radio" value="d"/> A multi-viscosity oil that reduces axial thrust.</label>
 </div>
 <div class="question">
-<p><strong>Question 11:</strong> Where is the friction clutch assembly located in a vehicle equipped with a manual transmission?</p>
+<p><strong>Where is the friction clutch assembly located in a vehicle equipped with a manual transmission?</p>
 <label><input name="q11" type="radio" value="a"/> Between the driveshaft and the rear axle assembly.</label>
 <label><input name="q11" type="radio" value="b"/> Between the output shaft and the engine crankshaft.</label>
 <label><input name="q11" type="radio" value="c"/> Between the engine flywheel and the transmission input shaft.</label>
 <label><input name="q11" type="radio" value="d"/> Between the clutch master and slave cylinders.</label>
 </div>
 <div class="question">
-<p><strong>Question 12:</strong> What is the explicit function of the torsional springs located within the hub of a spring-dampened clutch disc?</p>
+<p><strong>What is the explicit function of the torsional springs located within the hub of a spring-dampened clutch disc?</p>
 <label><input name="q12" type="radio" value="a"/> To cushion initial engagement against the flywheel.</label>
 <label><input name="q12" type="radio" value="b"/> To provide clutch pedal free play adjustment.</label>
 <label><input name="q12" type="radio" value="c"/> To absorb and dampen torque and engine power pulses.</label>
 <label><input name="q12" type="radio" value="d"/> To apply the pressure plate against the flywheel.</label>
 </div>
 <div class="question">
-<p><strong>Question 13:</strong> A technician must avoid installing a flywheel from an externally balanced engine onto an internally balanced engine (and vice versa). Why is this critical?</p>
+<p><strong>A technician must avoid installing a flywheel from an externally balanced engine onto an internally balanced engine (and vice versa). Why is this critical?</p>
 <label><input name="q13" type="radio" value="a"/> To ensure the flywheel can absorb and dissipate heat effectively.</label>
 <label><input name="q13" type="radio" value="b"/> To prevent the Marcel spring web from warping.</label>
 <label><input name="q13" type="radio" value="c"/> Because part of the engine balancing is accomplished by a balance weight incorporated into the flywheel.</label>
 <label><input name="q13" type="radio" value="d"/> To ensure the flywheel can rotate at high engine speeds.</label>
 </div>
 <div class="question">
-<p><strong>Question 14:</strong> Which clutch disc lining material is commonly used in heavy-duty truck applications because it provides very good resistance to slipping, despite potentially causing premature wear on the pressure plate and flywheel?</p>
+<p><strong>Which clutch disc lining material is commonly used in heavy-duty truck applications because it provides very good resistance to slipping, despite potentially causing premature wear on the pressure plate and flywheel?</p>
 <label><input name="q14" type="radio" value="a"/> Organic linings (NAO)</label>
 <label><input name="q14" type="radio" value="b"/> Semi-metallic linings</label>
 <label><input name="q14" type="radio" value="c"/> Ceramic button linings</label>
 <label><input name="q14" type="radio" value="d"/> Sintered bronze linings</label>
 </div>
 <div class="question">
-<p><strong>Question 15:</strong> What component, constructed of segmented, curved spring steel, provides cushioning during clutch engagement to prevent harshness?</p>
+<p><strong>What component, constructed of segmented, curved spring steel, provides cushioning during clutch engagement to prevent harshness?</p>
 <label><input name="q15" type="radio" value="a"/> Torsional Load Springs</label>
 <label><input name="q15" type="radio" value="b"/> Belleville Springs</label>
 <label><input name="q15" type="radio" value="c"/> Marcel Springs</label>
 <label><input name="q15" type="radio" value="d"/> Clutch Release Levers</label>
 </div>
 <div class="question">
-<p><strong>Question 16:</strong> The small bearing located in the bore of the flywheel or crankshaft serves what primary purpose?</p>
+<p><strong>The small bearing located in the bore of the flywheel or crankshaft serves what primary purpose?</p>
 <label><input name="q16" type="radio" value="a"/> To carry the axial load applied by the release bearing.</label>
 <label><input name="q16" type="radio" value="b"/> To absorb torsional shock during engagement.</label>
 <label><input name="q16" type="radio" value="c"/> To pilot (guide and align) the transmission input shaft.</label>
 <label><input name="q16" type="radio" value="d"/> To provide a friction surface for the clutch brake.</label>
 </div>
 <div class="question">
-<p><strong>Question 17:</strong> Clutch release bearings must be designed to withstand what type of specific load classification?</p>
+<p><strong>Clutch release bearings must be designed to withstand what type of specific load classification?</p>
 <label><input name="q17" type="radio" value="a"/> Radial load</label>
 <label><input name="q17" type="radio" value="b"/> Axial load (Thrust)</label>
 <label><input name="q17" type="radio" value="c"/> Centrifugal force</label>
 <label><input name="q17" type="radio" value="d"/> Torsional vibration</label>
 </div>
 <div class="question">
-<p><strong>Question 18:</strong> What is the primary purpose of the blocking ring component in a synchronizer assembly?</p>
+<p><strong>What is the primary purpose of the blocking ring component in a synchronizer assembly?</p>
 <label><input name="q18" type="radio" value="a"/> To transfer torque directly from the gear to the output shaft.</label>
 <label><input name="q18" type="radio" value="b"/> To act as a brake shoe to bring the output gear to the speed of the output shaft.</label>
 <label><input name="q18" type="radio" value="c"/> To provide a neutral location for the shift sleeve.</label>
 <label><input name="q18" type="radio" value="d"/> To lock out the selection of a second gear simultaneously.</label>
 </div>
 <div class="question">
-<p><strong>Question 19:</strong> In a transverse-mounted transaxle, what is the most significant physical difference compared to a manual transmission?</p>
+<p><strong>In a transverse-mounted transaxle, what is the most significant physical difference compared to a manual transmission?</p>
 <label><input name="q19" type="radio" value="a"/> Transaxles use helical gears, while transmissions use spur gears.</label>
 <label><input name="q19" type="radio" value="b"/> The output shaft runs parallel to the input shaft instead of directly behind it.</label>
 <label><input name="q19" type="radio" value="c"/> Transaxles must always be electronically controlled.</label>
 <label><input name="q19" type="radio" value="d"/> Transaxles require five shafts, while transmissions only require three.</label>
 </div>
 <div class="question">
-<p><strong>Question 20:</strong> What system, designed into the internal shift mechanism, is responsible for preventing the transmission or transaxle from hopping or jumping out of gear due to engine torque variations?</p>
+<p><strong>What system, designed into the internal shift mechanism, is responsible for preventing the transmission or transaxle from hopping or jumping out of gear due to engine torque variations?</p>
 <label><input name="q20" type="radio" value="a"/> The Interlock system.</label>
 <label><input name="q20" type="radio" value="b"/> The Synchronizer Unit.</label>
 <label><input name="q20" type="radio" value="c"/> The Detent system.</label>
 <label><input name="q20" type="radio" value="d"/> The External Linkage system.</label>
 </div>
 <div class="question">
-<p><strong>Question 21:</strong> The purpose of the interlock system in a manual transmission shift mechanism is to accomplish what goal?</p>
+<p><strong>The purpose of the interlock system in a manual transmission shift mechanism is to accomplish what goal?</p>
 <label><input name="q21" type="radio" value="a"/> Provide a positive feel when selecting a gear (detent function).</label>
 <label><input name="q21" type="radio" value="b"/> Ensure the operator exerts pressure to engage first or reverse.</label>
 <label><input name="q21" type="radio" value="c"/> Prevent the driver from selecting two gears at once.</label>
 <label><input name="q21" type="radio" value="d"/> Lock the output gear to the synchronizer hub during the shift.</label>
 </div>
 <div class="question">
-<p><strong>Question 22:</strong> When a five-speed transmission is in Neutral, what is the state of the power flow and internal components?</p>
+<p><strong>When a five-speed transmission is in Neutral, what is the state of the power flow and internal components?</p>
 <label><input name="q22" type="radio" value="a"/> All shafts and gears are stopped because the input shaft is disconnected from the engine.</label>
 <label><input name="q22" type="radio" value="b"/> The input shaft is spinning, but all gears are stopped, and the output shaft is locked.</label>
 <label><input name="q22" type="radio" value="c"/> The input shaft and all gears turn, but the output shaft does not, so no power is transmitted.</label>
 <label><input name="q22" type="radio" value="d"/> The synchronizers are all locked to their respective gears, but the idler gear freewheels.</label>
 </div>
 <div class="question">
-<p><strong>Question 23:</strong> When the driver selects 4th gear (Direct Drive) in a simplified five-speed transmission, the synchronizer sleeve moves to lock the output shaft directly to which component?</p>
+<p><strong>When the driver selects 4th gear (Direct Drive) in a simplified five-speed transmission, the synchronizer sleeve moves to lock the output shaft directly to which component?</p>
 <label><input name="q23" type="radio" value="a"/> The 4th output gear.</label>
 <label><input name="q23" type="radio" value="b"/> The cluster drive gear.</label>
 <label><input name="q23" type="radio" value="c"/> The input shaft.</label>
 <label><input name="q23" type="radio" value="d"/> The cluster 4th gear.</label>
 </div>
 <div class="question">
-<p><strong>Question 24:</strong> To keep lubrication circulating, light-duty manual transmissions and transaxles rely on which system?</p>
+<p><strong>To keep lubrication circulating, light-duty manual transmissions and transaxles rely on which system?</p>
 <label><input name="q24" type="radio" value="a"/> A pressure pump system feeding oil to galleries.</label>
 <label><input name="q24" type="radio" value="b"/> A combination pressure and splash system.</label>
 <label><input name="q24" type="radio" value="c"/> A splash system, where rotating gears throw oil onto components.</label>
 <label><input name="q24" type="radio" value="d"/> An external oil cooler system.</label>
 </div>
 <div class="question">
-<p><strong>Question 25:</strong> The high torque handling capacity of a twin countershaft transmission is achieved partly because the mainshaft gear is suspended or "floating" between the countershafts. This floating design eliminates the need for what components between the mainshaft and the mainshaft gears?</p>
+<p><strong>The high torque handling capacity of a twin countershaft transmission is achieved partly because the mainshaft gear is suspended or "floating" between the countershafts. This floating design eliminates the need for what components between the mainshaft and the mainshaft gears?</p>
 <label><input name="q25" type="radio" value="a"/> Sliding clutches.</label>
 <label><input name="q25" type="radio" value="b"/> Bearings (or bushings/shaft sleeves).</label>
 <label><input name="q25" type="radio" value="c"/> Thrust washers.</label>
 <label><input name="q25" type="radio" value="d"/> Mainshaft retaining rings.</label>
 </div>
 <div class="question">
-<p><strong>Question 26:</strong> The auxiliary section of a heavy-duty transmission is typically shifted using air signals. Which component in the range shift cylinder assembly prevents air from passing from one side of the piston to the other or into the transmission housing?</p>
+<p><strong>The auxiliary section of a heavy-duty transmission is typically shifted using air signals. Which component in the range shift cylinder assembly prevents air from passing from one side of the piston to the other or into the transmission housing?</p>
 <label><input name="q26" type="radio" value="a"/> The yoke assembly.</label>
 <label><input name="q26" type="radio" value="b"/> The range clutch.</label>
 <label><input name="q26" type="radio" value="c"/> O-rings.</label>
 <label><input name="q26" type="radio" value="d"/> The detent pin.</label>
 </div>
 <div class="question">
-<p><strong>Question 27:</strong> In the auxiliary section of a compound transmission, which type of gearing typically accounts for a large ratio change?</p>
+<p><strong>In the auxiliary section of a compound transmission, which type of gearing typically accounts for a large ratio change?</p>
 <label><input name="q27" type="radio" value="a"/> Splitter gearing.</label>
 <label><input name="q27" type="radio" value="b"/> Range gearing.</label>
 <label><input name="q27" type="radio" value="c"/> Deep reduction gearing (only available in Low Range).</label>
 <label><input name="q27" type="radio" value="d"/> Overdrive gearing (always 1:1).</label>
 </div>
 <div class="question">
-<p><strong>Question 28:</strong> The main section of heavy-duty multiple countershaft transmissions is classified as what design type?</p>
+<p><strong>The main section of heavy-duty multiple countershaft transmissions is classified as what design type?</p>
 <label><input name="q28" type="radio" value="a"/> Synchronized, constant mesh, helical gear design.</label>
 <label><input name="q28" type="radio" value="b"/> Synchronized, sliding gear design.</label>
 <label><input name="q28" type="radio" value="c"/> Non-synchronized, constant mesh, sliding clutch design.</label>
 <label><input name="q28" type="radio" value="d"/> Automated shift, synchronized constant mesh design.</label>
 </div>
 <div class="question">
-<p><strong>Question 29:</strong> The clutch brake is necessary for heavy-duty, non-synchronized transmissions for what purpose?</p>
+<p><strong>The clutch brake is necessary for heavy-duty, non-synchronized transmissions for what purpose?</p>
 <label><input name="q29" type="radio" value="a"/> To prevent the mainshaft gears from floating away from the countershafts.</label>
 <label><input name="q29" type="radio" value="b"/> To reduce the transmission of noise and vibration to the cab.</label>
 <label><input name="q29" type="radio" value="c"/> To stop the input shaft from turning when the operator shifts into a starting or reverse gear.</label>
 <label><input name="q29" type="radio" value="d"/> To lock out the inter-axle differential during a spin-out.</label>
 </div>
 <div class="question">
-<p><strong>Question 30:</strong> Which type of PTO actuation method allows the power takeoff unit to be safely engaged and disengaged while the vehicle is in motion?</p>
+<p><strong>Which type of PTO actuation method allows the power takeoff unit to be safely engaged and disengaged while the vehicle is in motion?</p>
 <label><input name="q30" type="radio" value="a"/> Cable actuated PTO.</label>
 <label><input name="q30" type="radio" value="b"/> Air actuated PTO (sliding gear).</label>
 <label><input name="q30" type="radio" value="c"/> Clutch shift actuated PTO (hot shift).</label>
 <label><input name="q30" type="radio" value="d"/> Electrically actuated PTO (solenoid controlled).</label>
 </div>
 <div class="question">
-<p><strong>Question 31:</strong> When installing a Power Takeoff (PTO), the gasket placed between the PTO and the transmission provides which two specific functional purposes?</p>
+<p><strong>When installing a Power Takeoff (PTO), the gasket placed between the PTO and the transmission provides which two specific functional purposes?</p>
 <label><input name="q31" type="radio" value="a"/> Adjusts driveline angle and reduces vibration.</label>
 <label><input name="q31" type="radio" value="b"/> Acts as a seal to prevent leaks and provides a way of setting the proper backlash.</label>
 <label><input name="q31" type="radio" value="c"/> Increases the torque output and filters the gear oil.</label>
 <label><input name="q31" type="radio" value="d"/> Transfers torque from the countershaft and dampens shock loads.</label>
 </div>
 <div class="question">
-<p><strong>Question 32:</strong> What critical action must the operator ensure before engaging a power takeoff (PTO) unit?</p>
+<p><strong>What critical action must the operator ensure before engaging a power takeoff (PTO) unit?</p>
 <label><input name="q32" type="radio" value="a"/> The main transmission must be shifted into Neutral.</label>
 <label><input name="q32" type="radio" value="b"/> The clutch is disengaged and the transmission gears are not turning.</label>
 <label><input name="q32" type="radio" value="c"/> The vehicle speed sensor must read 0.0 mph.</label>
 <label><input name="q32" type="radio" value="d"/> The air shift cylinder must be in the Low Range position.</label>
 </div>
 <div class="question">
-<p><strong>Question 33:</strong> A five-speed main transmission section combined with a three-speed auxiliary transmission provides the operator with how many possible forward gear selections?</p>
+<p><strong>A five-speed main transmission section combined with a three-speed auxiliary transmission provides the operator with how many possible forward gear selections?</p>
 <label><input name="q33" type="radio" value="a"/> 9</label>
 <label><input name="q33" type="radio" value="b"/> 15</label>
 <label><input name="q33" type="radio" value="c"/> 18</label>
 <label><input name="q33" type="radio" value="d"/> 20</label>
 </div>
 <div class="question">
-<p><strong>Question 34:</strong> Conventional cross-and-roller U-joints cause the shaft they are driving to speed up and slow down as they transfer rotational motion through an angle. This condition is known as:</p>
+<p><strong>Conventional cross-and-roller U-joints cause the shaft they are driving to speed up and slow down as they transfer rotational motion through an angle. This condition is known as:</p>
 <label><input name="q34" type="radio" value="a"/> Constant velocity.</label>
 <label><input name="q34" type="radio" value="b"/> Variable velocity.</label>
 <label><input name="q34" type="radio" value="c"/> Proper phasing.</label>
 <label><input name="q34" type="radio" value="d"/> Torsional dampening.</label>
 </div>
 <div class="question">
-<p><strong>Question 35:</strong> What is the normal maximum working drive angle recommended for a cross-and-roller universal joint (U-joint)?</p>
+<p><strong>What is the normal maximum working drive angle recommended for a cross-and-roller universal joint (U-joint)?</p>
 <label><input name="q35" type="radio" value="a"/> 5 °</label>
 <label><input name="q35" type="radio" value="b"/> 8 °</label>
 <label><input name="q35" type="radio" value="c"/> 12 °</label>
 <label><input name="q35" type="radio" value="d"/> 20 °</label>
 </div>
 <div class="question">
-<p><strong>Question 36:</strong> In Front-Wheel Drive (FWD) applications, torque steer is most often corrected by manufacturers using what method?</p>
+<p><strong>In Front-Wheel Drive (FWD) applications, torque steer is most often corrected by manufacturers using what method?</p>
 <label><input name="q36" type="radio" value="a"/> Replacing all fixed CV joints with plunging joints.</label>
 <label><input name="q36" type="radio" value="b"/> Using an intermediate shaft on the long side to equalize halfshaft length.</label>
 <label><input name="q36" type="radio" value="c"/> Mounting the transaxle assembly on a centre support bearing.</label>
 <label><input name="q36" type="radio" value="d"/> Eliminating the use of the double offset joint.</label>
 </div>
 <div class="question">
-<p><strong>Question 37:</strong> The Rzeppa CV joint is classified as a fixed depth joint. Where is it most commonly used in FWD vehicles?</p>
+<p><strong>The Rzeppa CV joint is classified as a fixed depth joint. Where is it most commonly used in FWD vehicles?</p>
 <label><input name="q37" type="radio" value="a"/> At the inboard end (at the transaxle).</label>
 <label><input name="q37" type="radio" value="b"/> On the propeller shaft (midship).</label>
 <label><input name="q37" type="radio" value="c"/> On the outboard end (at the wheel).</label>
 <label><input name="q37" type="radio" value="d"/> As the centre support bearing coupling shaft.</label>
 </div>
 <div class="question">
-<p><strong>Question 38:</strong> Which type of plunging CV joint uses a three-trunnion spider with rollers running on needle bearings and is typically used at the inboard position (at the transaxle) of front-wheel drive vehicles?</p>
+<p><strong>Which type of plunging CV joint uses a three-trunnion spider with rollers running on needle bearings and is typically used at the inboard position (at the transaxle) of front-wheel drive vehicles?</p>
 <label><input name="q38" type="radio" value="a"/> Rzeppa Joint</label>
 <label><input name="q38" type="radio" value="b"/> Tripod Joint (Tulip Joint)</label>
 <label><input name="q38" type="radio" value="c"/> Double Cardan Joint</label>
 <label><input name="q38" type="radio" value="d"/> Cross-Groove (Lobro) Joint</label>
 </div>
 <div class="question">
-<p><strong>Question 39:</strong> Since the Rzeppa joint is a fixed joint and does not allow for driveline length change, it must be used in conjunction with which other component type?</p>
+<p><strong>Since the Rzeppa joint is a fixed joint and does not allow for driveline length change, it must be used in conjunction with which other component type?</p>
 <label><input name="q39" type="radio" value="a"/> A fixed yoke</label>
 <label><input name="q39" type="radio" value="b"/> A constant velocity U-joint</label>
 <label><input name="q39" type="radio" value="c"/> A plunging joint or slip joint</label>
 <label><input name="q39" type="radio" value="d"/> A cross-and-roller U-joint</label>
 </div>
 <div class="question">
-<p><strong>Question 40:</strong> To be phased correctly in a driveshaft assembly, the two universal joints must be aligned so that the yokes on the same shaft are in what orientation?</p>
+<p><strong>To be phased correctly in a driveshaft assembly, the two universal joints must be aligned so that the yokes on the same shaft are in what orientation?</p>
 <label><input name="q40" type="radio" value="a"/> Rotated 90 ° relative to each other.</label>
 <label><input name="q40" type="radio" value="b"/> Tapered toward the center support bearing.</label>
 <label><input name="q40" type="radio" value="c"/> In the same plane (facing the same way).</label>
 <label><input name="q40" type="radio" value="d"/> Aligned precisely to the master spline.</label>
 </div>
 <div class="question">
-<p><strong>Question 41:</strong> What is the fundamental purpose of the light-duty drive axle gear sets?</p>
+<p><strong>What is the fundamental purpose of the light-duty drive axle gear sets?</p>
 <label><input name="q41" type="radio" value="a"/> To allow the drive wheels to turn at different speeds when cornering.</label>
 <label><input name="q41" type="radio" value="b"/> To provide a 90 ° change in the path of power.</label>
 <label><input name="q41" type="radio" value="c"/> To provide a final gear reduction resulting in a torque increase and a speed decrease.</label>
 <label><input name="q41" type="radio" value="d"/> To transmit torque from the differential case to the wheels.</label>
 </div>
 <div class="question">
-<p><strong>Question 42:</strong> In a semi-floating axle assembly, what is the sole function of the axle shaft?</p>
+<p><strong>In a semi-floating axle assembly, what is the sole function of the axle shaft?</p>
 <label><input name="q42" type="radio" value="a"/> Supporting the vehicle weight.</label>
 <label><input name="q42" type="radio" value="b"/> Transferring axial and radial loads.</label>
 <label><input name="q42" type="radio" value="c"/> Propelling the vehicle (transferring torque).</label>
 <label><input name="q42" type="radio" value="d"/> Supporting the wheel end with two tapered roller bearings.</label>
 </div>
 <div class="question">
-<p><strong>Question 43:</strong> The large curvature of the gear teeth in a hypoid gear set causes what consequence during meshing?</p>
+<p><strong>The large curvature of the gear teeth in a hypoid gear set causes what consequence during meshing?</p>
 <label><input name="q43" type="radio" value="a"/> It eliminates noise and vibration.</label>
 <label><input name="q43" type="radio" value="b"/> It reduces the requirement for EP additives.</label>
 <label><input name="q43" type="radio" value="c"/> It causes a great deal of side thrust.</label>
 <label><input name="q43" type="radio" value="d"/> It ensures torque is always divided equally.</label>
 </div>
 <div class="question">
-<p><strong>Question 44:</strong> Which type of semi-floating axle bearing configuration requires the use of a C-lock on the end of the axle shaft to transfer side thrust?</p>
+<p><strong>Which type of semi-floating axle bearing configuration requires the use of a C-lock on the end of the axle shaft to transfer side thrust?</p>
 <label><input name="q44" type="radio" value="a"/> Ball bearings</label>
 <label><input name="q44" type="radio" value="b"/> Tapered roller bearings</label>
 <label><input name="q44" type="radio" value="c"/> Straight roller bearings</label>
 <label><input name="q44" type="radio" value="d"/> Pilot bushings</label>
 </div>
 <div class="question">
-<p><strong>Question 45:</strong> In a standard differential, when a vehicle is rounding a corner, the differential pinion gears rotate on their shaft to transfer lost motion from the inside wheel to the outside wheel. What component is required to balance the forces and ensure torque is split equally between the two axle side gears?</p>
+<p><strong>In a standard differential, when a vehicle is rounding a corner, the differential pinion gears rotate on their shaft to transfer lost motion from the inside wheel to the outside wheel. What component is required to balance the forces and ensure torque is split equally between the two axle side gears?</p>
 <label><input name="q45" type="radio" value="a"/> The thrust washer on the differential case.</label>
 <label><input name="q45" type="radio" value="b"/> The differential case side bearings.</label>
 <label><input name="q45" type="radio" value="c"/> The differential pinion shaft.</label>
 <label><input name="q45" type="radio" value="d"/> The pinion position shims.</label>
 </div>
 <div class="question">
-<p><strong>Question 46:</strong> What specialized chemical additive is generally required for gear oil when a vehicle is equipped with a limited slip differential (LSD) assembly (Disc Clutch type)?</p>
+<p><strong>What specialized chemical additive is generally required for gear oil when a vehicle is equipped with a limited slip differential (LSD) assembly (Disc Clutch type)?</p>
 <label><input name="q46" type="radio" value="a"/> Anti-foaming agent.</label>
 <label><input name="q46" type="radio" value="b"/> Extreme-pressure (EP) additive.</label>
 <label><input name="q46" type="radio" value="c"/> Friction modifier.</label>
 <label><input name="q46" type="radio" value="d"/> Viscosity stabilizer.</label>
 </div>
 <div class="question">
-<p><strong>Question 47:</strong> If the drive axle breather vent is restricted or plugged, what problem may occur?</p>
+<p><strong>If the drive axle breather vent is restricted or plugged, what problem may occur?</p>
 <label><input name="q47" type="radio" value="a"/> Gear oil viscosity will increase dramatically.</label>
 <label><input name="q47" type="radio" value="b"/> The differential clutch packs will fail to preload.</label>
 <label><input name="q47" type="radio" value="c"/> Fluid leaks from any of the axle housing seals (due to excess pressure).</label>
 <label><input name="q47" type="radio" value="d"/> The ring gear will fail to splash oil onto the pinion bearings.</label>
 </div>
 <div class="question">
-<p><strong>Question 48:</strong> A single-speed double reduction carrier assembly performs its second gear reduction through a set of:</p>
+<p><strong>A single-speed double reduction carrier assembly performs its second gear reduction through a set of:</p>
 <label><input name="q48" type="radio" value="a"/> Hypoid gears.</label>
 <label><input name="q48" type="radio" value="b"/> Spur gears.</label>
 <label><input name="q48" type="radio" value="c"/> Helical gears.</label>
 <label><input name="q48" type="radio" value="d"/> Planetary pinion gears.</label>
 </div>
 <div class="question">
-<p><strong>Question 49:</strong> In a planetary two-speed drive axle assembly, when operating in High Speed, the overall gear reduction is provided through only which components?</p>
+<p><strong>In a planetary two-speed drive axle assembly, when operating in High Speed, the overall gear reduction is provided through only which components?</p>
 <label><input name="q49" type="radio" value="a"/> The planetary gear set.</label>
 <label><input name="q49" type="radio" value="b"/> The crown gear set (single reduction).</label>
 <label><input name="q49" type="radio" value="c"/> The planetary gear set and the crown gear set (double reduction).</label>
 <label><input name="q49" type="radio" value="d"/> The inter-axle differential assembly.</label>
 </div>
 <div class="question">
-<p><strong>Question 50:</strong> What does the Gross Axle Weight Rating (GAWR), which is the manufacturer's rating stamped on the axle, dictate?</p>
+<p><strong>What does the Gross Axle Weight Rating (GAWR), which is the manufacturer's rating stamped on the axle, dictate?</p>
 <label><input name="q50" type="radio" value="a"/> The maximum permissible driveshaft speed.</label>
 <label><input name="q50" type="radio" value="b"/> The construction of the housing, bearings, and wheel ends based on the weight the axle must safely carry.</label>
 <label><input name="q50" type="radio" value="c"/> The torque multiplication capacity of the gear set.</label>
 <label><input name="q50" type="radio" value="d"/> The type of lubrication required (splash or pressure).</label>
 </div>
 <div class="question">
-<p><strong>Question 51:</strong> What is the fundamental purpose of the inter-axle differential lockout assembly?</p>
+<p><strong>What is the fundamental purpose of the inter-axle differential lockout assembly?</p>
 <label><input name="q51" type="radio" value="a"/> To allow speed differences between the two drive axle pinions during cornering.</label>
 <label><input name="q51" type="radio" value="b"/> To provide maximum traction on dry road surfaces.</label>
 <label><input name="q51" type="radio" value="c"/> To lock out inter-axle differential action and provide torque to both drive axles evenly.</label>
 <label><input name="q51" type="radio" value="d"/> To ensure the bevel gear is constantly turning at the same speed as the input shaft.</label>
 </div>
 <div class="question">
-<p><strong>Question 52:</strong> During normal operation (lockout disengaged), how does the inter-axle differential assembly divide torque between the forward and rearward drive axle assemblies?</p>
+<p><strong>During normal operation (lockout disengaged), how does the inter-axle differential assembly divide torque between the forward and rearward drive axle assemblies?</p>
 <label><input name="q52" type="radio" value="a"/> Torque is directed to the axle with the least traction.</label>
 <label><input name="q52" type="radio" value="b"/> The torque split is variable depending on vehicle load.</label>
 <label><input name="q52" type="radio" value="c"/> Torque is divided equally between the two drive axle assemblies.</label>
 <label><input name="q52" type="radio" value="d"/> Torque transfer is stopped entirely if there is a speed difference.</label>
 </div>
 <div class="question">
-<p><strong>Question 53:</strong> The vast majority of drive axle assemblies are lubricated using which basic system?</p>
+<p><strong>The vast majority of drive axle assemblies are lubricated using which basic system?</p>
 <label><input name="q53" type="radio" value="a"/> Combination splash and pressure system.</label>
 <label><input name="q53" type="radio" value="b"/> Dedicated pressure pump and external filter system.</label>
 <label><input name="q53" type="radio" value="c"/> Splash lubrication system.</label>
 <label><input name="q53" type="radio" value="d"/> Oil gallery and trough system only.</label>
 </div>
 <div class="question">
-<p><strong>Question 54:</strong> If a parts technician sells a customer the wrong type of gear oil and it is mixed with the existing lubricant in the drive axle housing, what is the consequence?</p>
+<p><strong>If a parts technician sells a customer the wrong type of gear oil and it is mixed with the existing lubricant in the drive axle housing, what is the consequence?</p>
 <label><input name="q54" type="radio" value="a"/> The fluid's viscosity rating will increase.</label>
 <label><input name="q54" type="radio" value="b"/> The gear oil causes a breakdown chemically.</label>
 <label><input name="q54" type="radio" value="c"/> The oil will resist rust and corrosion more effectively.</label>
 <label><input name="q54" type="radio" value="d"/> The total fluid capacity of the housing is reduced.</label>
 </div>
 <div class="question">
-<p><strong>Question 55:</strong> What is the main purpose of four-wheel drive (4WD) and all-wheel drive (AWD) systems?</p>
+<p><strong>What is the main purpose of four-wheel drive (4WD) and all-wheel drive (AWD) systems?</p>
 <label><input name="q55" type="radio" value="a"/> To increase fuel economy on long trips.</label>
 <label><input name="q55" type="radio" value="b"/> To equalize the torque split between the inside and outside wheels.</label>
 <label><input name="q55" type="radio" value="c"/> To increase traction on slippery road surfaces.</label>
 <label><input name="q55" type="radio" value="d"/> To eliminate the need for a center differential.</label>
 </div>
 <div class="question">
-<p><strong>Question 56:</strong> The viscous coupling unit in a full-time transfer case is designed to lock up and deliver power to the axle with traction when the rate of slippage between the front and rear axles approaches what threshold?</p>
+<p><strong>The viscous coupling unit in a full-time transfer case is designed to lock up and deliver power to the axle with traction when the rate of slippage between the front and rear axles approaches what threshold?</p>
 <label><input name="q56" type="radio" value="a"/> 2%</label>
 <label><input name="q56" type="radio" value="b"/> 6%</label>
 <label><input name="q56" type="radio" value="c"/> 10%</label>
 <label><input name="q56" type="radio" value="d"/> 15%</label>
 </div>
 <div class="question">
-<p><strong>Question 57:</strong> When is a drive system typically classified as All-Wheel Drive (AWD)?</p>
+<p><strong>When is a drive system typically classified as All-Wheel Drive (AWD)?</p>
 <label><input name="q57" type="radio" value="a"/> When it requires the driver to manually engage the front axle.</label>
 <label><input name="q57" type="radio" value="b"/> When the system uses mechanical locking hubs.</label>
 <label><input name="q57" type="radio" value="c"/> When the system is permanently engaged or automatically engaging four-wheel drive.</label>
 <label><input name="q57" type="radio" value="d"/> When it only uses a chain drive to transfer power.</label>
 </div>
 <div class="question">
-<p><strong>Question 58:</strong> In the NV-246 electronic transfer case operating in Auto 4WD mode, the ATCM uses the Front Output Shaft Speed Sensor data to determine what critical operational metrics?</p>
+<p><strong>In the NV-246 electronic transfer case operating in Auto 4WD mode, the ATCM uses the Front Output Shaft Speed Sensor data to determine what critical operational metrics?</p>
 <label><input name="q58" type="radio" value="a"/> The engine load and vehicle speed (VSS).</label>
 <label><input name="q58" type="radio" value="b"/> The rear output shaft speed and the encoder motor position.</label>
 <label><input name="q58" type="radio" value="c"/> The amount of slip and the percent of torque to apply to the front axle.</label>
 <label><input name="q58" type="radio" value="d"/> The required deep reduction gear ratio.</label>
 </div>
 <div class="question">
-<p><strong>Question 59:</strong> In the NV-246 system, when the transfer case is placed in 2HI, 4HI, or 4LO, what is the state of the transfer case motor lock circuit?</p>
+<p><strong>In the NV-246 system, when the transfer case is placed in 2HI, 4HI, or 4LO, what is the state of the transfer case motor lock circuit?</p>
 <label><input name="q59" type="radio" value="a"/> The lock circuit is energized, allowing the encoder motor to rotate.</label>
 <label><input name="q59" type="radio" value="b"/> The motor lock circuit has no voltage provided to it, applying the lock.</label>
 <label><input name="q59" type="radio" value="c"/> The lock releases to allow transfer of torque to the front propeller shaft.</label>
 <label><input name="q59" type="radio" value="d"/> The lock circuit is energized to prevent gear clash.</label>
 </div>
 <div class="question">
-<p><strong>Question 60:</strong> Power is typically transferred to the front output shaft in a gear type transfer case operating in 4H or 4L via which mechanism?</p>
+<p><strong>Power is typically transferred to the front output shaft in a gear type transfer case operating in 4H or 4L via which mechanism?</p>
 <label><input name="q60" type="radio" value="a"/> Planetary gears and a center differential.</label>
 <label><input name="q60" type="radio" value="b"/> A chain drive or gears.</label>
 <label><input name="q60" type="radio" value="c"/> The Vehicle Speed Sensor (VSS) and an ATCM.</label>
 <label><input name="q60" type="radio" value="d"/> A hydraulic multi-plate clutch only.</label>
 </div>
 <div class="question">
-<p><strong>Question 61:</strong> After operating a vehicle with automatic locking hubs in four-wheel drive, what procedure is required to unlock the hubs?</p>
+<p><strong>After operating a vehicle with automatic locking hubs in four-wheel drive, what procedure is required to unlock the hubs?</p>
 <label><input name="q61" type="radio" value="a"/> Stop the vehicle and shift the transfer case back into 2H.</label>
 <label><input name="q61" type="radio" value="b"/> Drive forward one to two metres after shifting the transfer case to 2H.</label>
 <label><input name="q61" type="radio" value="c"/> Completely stop the vehicle, shift out of four-wheel drive, and back the vehicle up one to two metres (three to six feet).</label>
 <label><input name="q61" type="radio" value="d"/> Turn the selector switch on the dashboard to the "FREE" position.</label>
 </div>
 <div class="question">
-<p><strong>Question 62:</strong> All automatic transmissions consist of which three major functional sections?</p>
+<p><strong>All automatic transmissions consist of which three major functional sections?</p>
 <label><input name="q62" type="radio" value="a"/> Impeller, turbine, and stator.</label>
 <label><input name="q62" type="radio" value="b"/> Oil pump, oil pan, and extension housing.</label>
 <label><input name="q62" type="radio" value="c"/> Torque converter, planetary gear set unit, and hydraulic control system.</label>
 <label><input name="q62" type="radio" value="d"/> Valve body, accumulator, and governor.</label>
 </div>
 <div class="question">
-<p><strong>Question 63:</strong> Which component of a lockup torque converter is used to provide direct drive from the engine to the transmission, eliminating slippage?</p>
+<p><strong>Which component of a lockup torque converter is used to provide direct drive from the engine to the transmission, eliminating slippage?</p>
 <label><input name="q63" type="radio" value="a"/> The impeller (pump).</label>
 <label><input name="q63" type="radio" value="b"/> The one-way clutch (stator).</label>
 <label><input name="q63" type="radio" value="c"/> The Torque Converter Clutch (TCC).</label>
 <label><input name="q63" type="radio" value="d"/> The flex plate.</label>
 </div>
 <div class="question">
-<p><strong>Question 64:</strong> Vortex flow in a torque converter occurs when the turbine is turning at a lower rate of speed than the impeller. What operational characteristics accompany this flow?</p>
+<p><strong>Vortex flow in a torque converter occurs when the turbine is turning at a lower rate of speed than the impeller. What operational characteristics accompany this flow?</p>
 <label><input name="q64" type="radio" value="a"/> Low heat, high output speed, and low torque.</label>
 <label><input name="q64" type="radio" value="b"/> High heat, low output speed, and high torque.</label>
 <label><input name="q64" type="radio" value="c"/> Freewheeling of the stator one-way clutch.</label>
 <label><input name="q64" type="radio" value="d"/> The TCC is mechanically locked to the stator support.</label>
 </div>
 <div class="question">
-<p><strong>Question 65:</strong> The coupling point in a conventional torque converter is the point at which:</p>
+<p><strong>The coupling point in a conventional torque converter is the point at which:</p>
 <label><input name="q65" type="radio" value="a"/> The torque multiplication ratio reaches 3.00:1.</label>
 <label><input name="q65" type="radio" value="b"/> The turbine reaches 9/10 the speed of the impeller.</label>
 <label><input name="q65" type="radio" value="c"/> The oil flow within the converter stops completely.</label>
 <label><input name="q65" type="radio" value="d"/> The vortex flow is at its maximum.</label>
 </div>
 <div class="question">
-<p><strong>Question 66:</strong> What is the explicit functional purpose of the stator in a non-lockup torque converter?</p>
+<p><strong>What is the explicit functional purpose of the stator in a non-lockup torque converter?</p>
 <label><input name="q66" type="radio" value="a"/> To dampen engine torsional pulses.</label>
 <label><input name="q66" type="radio" value="b"/> To provide a permanent mechanical lockup.</label>
 <label><input name="q66" type="radio" value="c"/> To intercept the oil coming out of the turbine and redirect it back to the impeller to assist rotation.</label>
 <label><input name="q66" type="radio" value="d"/> To act as a reservoir for fluid during the stall condition.</label>
 </div>
 <div class="question">
-<p><strong>Question 67:</strong> To achieve torque multiplication, the stator must be in which operational state during vehicle acceleration?</p>
+<p><strong>To achieve torque multiplication, the stator must be in which operational state during vehicle acceleration?</p>
 <label><input name="q67" type="radio" value="a"/> Freewheeling, allowing it to rotate clockwise.</label>
 <label><input name="q67" type="radio" value="b"/> Held stationary (locked to the stator support).</label>
 <label><input name="q67" type="radio" value="c"/> Rotating in the opposite direction of the impeller.</label>
 <label><input name="q67" type="radio" value="d"/> Disengaged from the one-way clutch.</label>
 </div>
 <div class="question">
-<p><strong>Question 68:</strong> When the lockup clutch is in its engaged position, what is the state of the fluid flow through the torque converter?</p>
+<p><strong>When the lockup clutch is in its engaged position, what is the state of the fluid flow through the torque converter?</p>
 <label><input name="q68" type="radio" value="a"/> Fluid flows inward, maximizing torque multiplication.</label>
 <label><input name="q68" type="radio" value="b"/> Fluid flows outward, preventing clutch pressure buildup.</label>
 <label><input name="q68" type="radio" value="c"/> Fluid flow stops completely, and pressure builds to a predetermined value.</label>
 <label><input name="q68" type="radio" value="d"/> Fluid flows in rotary motion, providing a 1:1 coupling.</label>
 </div>
 <div class="question">
-<p><strong>Question 69:</strong> How is the process of locking the lockup torque converter clutch accomplished hydraulically?</p>
+<p><strong>How is the process of locking the lockup torque converter clutch accomplished hydraulically?</p>
 <label><input name="q69" type="radio" value="a"/> By closing the oil cooler bypass valve.</label>
 <label><input name="q69" type="radio" value="b"/> By reversing the oil flow, forcing fluid into the back side of the converter.</label>
 <label><input name="q69" type="radio" value="c"/> By utilizing maximum vortex flow to apply the piston.</label>
 <label><input name="q69" type="radio" value="d"/> By engaging the brake switch, which applies the apply piston.</label>
 </div>
 <div class="question">
-<p><strong>Question 70:</strong> The variable displacement vane pump output volume and system pressure are directly controlled by the operation of which component?</p>
+<p><strong>The variable displacement vane pump output volume and system pressure are directly controlled by the operation of which component?</p>
 <label><input name="q70" type="radio" value="a"/> The crescent pump drive gear.</label>
 <label><input name="q70" type="radio" value="b"/> The priming spring.</label>
 <label><input name="q70" type="radio" value="c"/> The pressure regulator valve.</label>
 <label><input name="q70" type="radio" value="d"/> The rotor guide ring.</label>
 </div>
 <div class="question">
-<p><strong>Question 71:</strong> Fixed displacement automatic transmission oil pumps (gear or rotor types) discharge an amount of oil that is proportional to what?</p>
+<p><strong>Fixed displacement automatic transmission oil pumps (gear or rotor types) discharge an amount of oil that is proportional to what?</p>
 <label><input name="q71" type="radio" value="a"/> The required line pressure.</label>
 <label><input name="q71" type="radio" value="b"/> Engine speed.</label>
 <label><input name="q71" type="radio" value="c"/> The capacity of the torque converter.</label>
 <label><input name="q71" type="radio" value="d"/> The shift solenoid duty cycle.</label>
 </div>
 <div class="question">
-<p><strong>Question 72:</strong> What is the purpose of the red dye added to most automatic transmission fluids?</p>
+<p><strong>What is the purpose of the red dye added to most automatic transmission fluids?</p>
 <label><input name="q72" type="radio" value="a"/> To prevent foaming and oxidation.</label>
 <label><input name="q72" type="radio" value="b"/> To enhance the fluid's high viscosity index.</label>
 <label><input name="q72" type="radio" value="c"/> To distinguish it from engine oil.</label>
 <label><input name="q72" type="radio" value="d"/> To maximize the fluid's high-frictional coefficient.</label>
 </div>
 <div class="question">
-<p><strong>Question 73:</strong> Automatic transmission fluid (ATF) consists primarily of base oil and performance additives. What is the approximate range for the percentage of base oil content?</p>
+<p><strong>Automatic transmission fluid (ATF) consists primarily of base oil and performance additives. What is the approximate range for the percentage of base oil content?</p>
 <label><input name="q73" type="radio" value="a"/> 70% to 75%</label>
 <label><input name="q73" type="radio" value="b"/> 85% to 90%</label>
 <label><input name="q73" type="radio" value="c"/> 50% to 60%</label>
 <label><input name="q73" type="radio" value="d"/> 95% to 100%</label>
 </div>
 <div class="question">
-<p><strong>Question 74:</strong> What is the ideal running temperature range for automatic transmission fluid?</p>
+<p><strong>What is the ideal running temperature range for automatic transmission fluid?</p>
 <label><input name="q74" type="radio" value="a"/> Below 55 °C (130 °F)</label>
 <label><input name="q74" type="radio" value="b"/> 37 °C to 80 °C (100 °F to 175 °F)</label>
 <label><input name="q74" type="radio" value="c"/> 90 °C to 120 °C (194 °F to 248 °F)</label>
 <label><input name="q74" type="radio" value="d"/> Above 150 °C (300 °F)</label>
 </div>
 <div class="question">
-<p><strong>Question 75:</strong> Planetary gear sets are capable of handling large torque loads for their small size because:</p>
+<p><strong>Planetary gear sets are capable of handling large torque loads for their small size because:</p>
 <label><input name="q75" type="radio" value="a"/> They use helical gears which generate minimal end thrust.</label>
 <label><input name="q75" type="radio" value="b"/> The torque load is distributed over several planet pinion gears, providing more teeth in contact.</label>
 <label><input name="q75" type="radio" value="c"/> They operate almost exclusively in Direct Drive (1:1 ratio).</label>
 <label><input name="q75" type="radio" value="d"/> They are made of stamped steel, reducing component weight.</label>
 </div>
 <div class="question">
-<p><strong>Question 76:</strong> In a simple planetary gear set, if the Sun Gear is held stationary and the Internal/Ring Gear is used as the input member, what operational condition is achieved?</p>
+<p><strong>In a simple planetary gear set, if the Sun Gear is held stationary and the Internal/Ring Gear is used as the input member, what operational condition is achieved?</p>
 <label><input name="q76" type="radio" value="a"/> Reverse Reduction</label>
 <label><input name="q76" type="radio" value="b"/> Forward Overdrive</label>
 <label><input name="q76" type="radio" value="c"/> Forward Reduction</label>
 <label><input name="q76" type="radio" value="d"/> Reverse Overdrive</label>
 </div>
 <div class="question">
-<p><strong>Question 77:</strong> If the Sun Gear is held stationary and the Planet Carrier is the input member, what operational condition is achieved?</p>
+<p><strong>If the Sun Gear is held stationary and the Planet Carrier is the input member, what operational condition is achieved?</p>
 <label><input name="q77" type="radio" value="a"/> Reverse Reduction</label>
 <label><input name="q77" type="radio" value="b"/> Forward Overdrive</label>
 <label><input name="q77" type="radio" value="c"/> Forward Deep Reduction</label>
 <label><input name="q77" type="radio" value="d"/> Neutral</label>
 </div>
 <div class="question">
-<p><strong>Question 78:</strong> Which of the following conditions achieves Direct Drive (1:1 ratio) in a planetary gear set?</p>
+<p><strong>Which of the following conditions achieves Direct Drive (1:1 ratio) in a planetary gear set?</p>
 <label><input name="q78" type="radio" value="a"/> Only the sun gear is freewheeling.</label>
 <label><input name="q78" type="radio" value="b"/> The planetary carrier is held stationary.</label>
 <label><input name="q78" type="radio" value="c"/> Driving any two members at the same speed or locking any two members together.</label>
 <label><input name="q78" type="radio" value="d"/> The ring gear is held stationary and the sun gear is the input.</label>
 </div>
 <div class="question">
-<p><strong>Question 79:</strong> The freewheeling action of a one-way clutch serves what explicit purpose in the automatic transmission?</p>
+<p><strong>The freewheeling action of a one-way clutch serves what explicit purpose in the automatic transmission?</p>
 <label><input name="q79" type="radio" value="a"/> To lock the clutch support to the transmission case.</label>
 <label><input name="q79" type="radio" value="b"/> To improve shift quality by eliminating a timing problem during band-to-band or band-to-clutch shifts.</label>
 <label><input name="q79" type="radio" value="c"/> To provide a high degree of frictional drag in the freewheeling mode.</label>
 <label><input name="q79" type="radio" value="d"/> To manually apply the piston when hydraulic pressure is insufficient.</label>
 </div>
 <div class="question">
-<p><strong>Question 80:</strong> What factor is primarily responsible for determining the torque capacity of a multiple-disc hydraulic clutch pack assembly?</p>
+<p><strong>What factor is primarily responsible for determining the torque capacity of a multiple-disc hydraulic clutch pack assembly?</p>
 <label><input name="q80" type="radio" value="a"/> The force provided by the return springs.</label>
 <label><input name="q80" type="radio" value="b"/> The number of contacting surfaces (clutch plates and friction discs).</label>
 <label><input name="q80" type="radio" value="c"/> The thickness of the steel plates in the stack.</label>
 <label><input name="q80" type="radio" value="d"/> The diameter of the clutch apply piston.</label>
 </div>
 <div class="question">
-<p><strong>Question 81:</strong> A transmission band is always used in what capacity relative to the planetary gear set?</p>
+<p><strong>A transmission band is always used in what capacity relative to the planetary gear set?</p>
 <label><input name="q81" type="radio" value="a"/> As a driving member to supply torque input.</label>
 <label><input name="q81" type="radio" value="b"/> As a holding (reaction) member.</label>
 <label><input name="q81" type="radio" value="c"/> As an output member to transfer torque to the mainshaft.</label>
 <label><input name="q81" type="radio" value="d"/> As a torsional dampener to absorb shock.</label>
 </div>
 <div class="question">
-<p><strong>Question 82:</strong> What is the purpose of the small steel ball-type check valve found in some clutch pistons or drums?</p>
+<p><strong>What is the purpose of the small steel ball-type check valve found in some clutch pistons or drums?</p>
 <label><input name="q82" type="radio" value="a"/> To prevent the waved snap rings from flattening.</label>
 <label><input name="q82" type="radio" value="b"/> To provide a vacuum break when the clutch is applied.</label>
 <label><input name="q82" type="radio" value="c"/> To allow residual oil to escape when the clutch is released and turning at high RPM.</label>
 <label><input name="q82" type="radio" value="d"/> To supply hydraulic pressure to the clutch plates.</label>
 </div>
 <div class="question">
-<p><strong>Question 83:</strong> What is the specific function of a waved steel plate or waved snap ring in a clutch pack assembly?</p>
+<p><strong>What is the specific function of a waved steel plate or waved snap ring in a clutch pack assembly?</p>
 <label><input name="q83" type="radio" value="a"/> To act as a seal to prevent oil leakage from the drum.</label>
 <label><input name="q83" type="radio" value="b"/> To act as a cushioning device to smooth engagement.</label>
 <label><input name="q83" type="radio" value="c"/> To hold the clutch drum stationary to achieve reduction.</label>
 <label><input name="q83" type="radio" value="d"/> To lock the clutch drum to the case splines.</label>
 </div>
 <div class="question">
-<p><strong>Question 84:</strong> Double-wrap bands provide greater holding ability than single-wrap bands primarily due to which characteristic?</p>
+<p><strong>Double-wrap bands provide greater holding ability than single-wrap bands primarily due to which characteristic?</p>
 <label><input name="q84" type="radio" value="a"/> They require greater hydraulic pressure to apply.</label>
 <label><input name="q84" type="radio" value="b"/> They are made exclusively of semi-metallic friction material.</label>
 <label><input name="q84" type="radio" value="c"/> The self-energizing or wrap-around action of its connecting segments.</label>
 <label><input name="q84" type="radio" value="d"/> They are only used in Manual Low (L1) and Reverse (R) applications.</label>
 </div>
 <div class="question">
-<p><strong>Question 85:</strong> Single-acting servos are generally used for which transmission applications?</p>
+<p><strong>Single-acting servos are generally used for which transmission applications?</p>
 <label><input name="q85" type="radio" value="a"/> Those requiring a timed band release during upshifts.</label>
 <label><input name="q85" type="radio" value="b"/> Applications that involve continuous high-speed rotation.</label>
 <label><input name="q85" type="radio" value="c"/> Applications that do not involve automatic upshifts, such as Manual Low (ML) or Reverse (R).</label>
 <label><input name="q85" type="radio" value="d"/> Those that require the servo to operate as a pressure accumulator.</label>
 </div>
 <div class="question">
-<p><strong>Question 86:</strong> When a double-acting servo releases the band, pressure is directed to the release side of the piston. What is the state of the apply pressure during this release?</p>
+<p><strong>When a double-acting servo releases the band, pressure is directed to the release side of the piston. What is the state of the apply pressure during this release?</p>
 <label><input name="q86" type="radio" value="a"/> Apply pressure is instantly exhausted to the sump.</label>
 <label><input name="q86" type="radio" value="b"/> Apply pressure remains on the apply side of the servo piston.</label>
 <label><input name="q86" type="radio" value="c"/> The apply pressure reverses direction to aid the release spring.</label>
 <label><input name="q86" type="radio" value="d"/> The solenoid cuts off all hydraulic pressure to the servo.</label>
 </div>
 <div class="question">
-<p><strong>Question 87:</strong> Which type of band friction material is used in applications where the band is operating under static conditions (the drum is stationary when the band is applied), such as Manual Low or Reverse?</p>
+<p><strong>Which type of band friction material is used in applications where the band is operating under static conditions (the drum is stationary when the band is applied), such as Manual Low or Reverse?</p>
 <label><input name="q87" type="radio" value="a"/> Organic (paper pulp or cellulose).</label>
 <label><input name="q87" type="radio" value="b"/> Semi-metallic material.</label>
 <label><input name="q87" type="radio" value="c"/> Stamped steel.</label>
 <label><input name="q87" type="radio" value="d"/> Lathe-cut Teflon.</label>
 </div>
 <div class="question">
-<p><strong>Question 88:</strong> Which component is the most commonly used valve type in an automatic transmission when a valve must interconnect several passages or react to more than one pressure?</p>
+<p><strong>Which component is the most commonly used valve type in an automatic transmission when a valve must interconnect several passages or react to more than one pressure?</p>
 <label><input name="q88" type="radio" value="a"/> Check valve</label>
 <label><input name="q88" type="radio" value="b"/> Ball-type relief valve</label>
 <label><input name="q88" type="radio" value="c"/> Spool valve</label>
 <label><input name="q88" type="radio" value="d"/> Bypass valve</label>
 </div>
 <div class="question">
-<p><strong>Question 89:</strong> What is the functional purpose of the throttle valve (TV) in a transmission hydraulic circuit?</p>
+<p><strong>What is the functional purpose of the throttle valve (TV) in a transmission hydraulic circuit?</p>
 <label><input name="q89" type="radio" value="a"/> To regulate mainline pressure based on output shaft speed.</label>
 <label><input name="q89" type="radio" value="b"/> To provide maximum line pressure regardless of engine load.</label>
 <label><input name="q89" type="radio" value="c"/> To provide pressure that varies with throttle opening or engine load.</label>
 <label><input name="q89" type="radio" value="d"/> To restrict fluid flow to the governor valve.</label>
 </div>
 <div class="question">
-<p><strong>Question 90:</strong> When the engine vacuum is low (wide open throttle or WOT), what is the resulting hydraulic output pressure produced by the vacuum modulator?</p>
+<p><strong>When the engine vacuum is low (wide open throttle or WOT), what is the resulting hydraulic output pressure produced by the vacuum modulator?</p>
 <label><input name="q90" type="radio" value="a"/> Minimum pressure, close to 0 psi.</label>
 <label><input name="q90" type="radio" value="b"/> Pressure proportional to the centrifugal force.</label>
 <label><input name="q90" type="radio" value="c"/> High pressure equal to the incoming line pressure.</label>
 <label><input name="q90" type="radio" value="d"/> Pressure equal to the exhaust port setting.</label>
 </div>
 <div class="question">
-<p><strong>Question 91:</strong> Shift valves are referred to as switch valves because they are spool-type valves that function as what device in a hydraulic circuit?</p>
+<p><strong>Shift valves are referred to as switch valves because they are spool-type valves that function as what device in a hydraulic circuit?</p>
 <label><input name="q91" type="radio" value="a"/> A pressure relief valve.</label>
 <label><input name="q91" type="radio" value="b"/> A balanced (regulating) valve.</label>
 <label><input name="q91" type="radio" value="c"/> A simple on/off switch.</label>
 <label><input name="q91" type="radio" value="d"/> A continuously variable restriction valve.</label>
 </div>
 <div class="question">
-<p><strong>Question 92:</strong> In a four-speed automatic transmission, how many shift valves are required to control the gear changes?</p>
+<p><strong>In a four-speed automatic transmission, how many shift valves are required to control the gear changes?</p>
 <label><input name="q92" type="radio" value="a"/> Two shift valves.</label>
 <label><input name="q92" type="radio" value="b"/> Three shift valves.</label>
 <label><input name="q92" type="radio" value="c"/> Four shift valves.</label>
 <label><input name="q92" type="radio" value="d"/> Five shift valves.</label>
 </div>
 <div class="question">
-<p><strong>Question 93:</strong> What is the output pressure produced by the governor directly proportional to?</p>
+<p><strong>What is the output pressure produced by the governor directly proportional to?</p>
 <label><input name="q93" type="radio" value="a"/> Engine manifold vacuum.</label>
 <label><input name="q93" type="radio" value="b"/> Throttle position.</label>
 <label><input name="q93" type="radio" value="c"/> The rate of rotation (road or vehicle speed).</label>
 <label><input name="q93" type="radio" value="d"/> The mainline pressure boost setting.</label>
 </div>
 <div class="question">
-<p><strong>Question 94:</strong> When a governor valve is fully open, what is the maximum pressure it can produce?</p>
+<p><strong>When a governor valve is fully open, what is the maximum pressure it can produce?</p>
 <label><input name="q94" type="radio" value="a"/> 0 psi</label>
 <label><input name="q94" type="radio" value="b"/> Pressure equal to the throttle valve pressure.</label>
 <label><input name="q94" type="radio" value="c"/> Pressure equal to mainline pressure.</label>
 <label><input name="q94" type="radio" value="d"/> Pressure determined by the spring tension only.</label>
 </div>
 <div class="question">
-<p><strong>Question 95:</strong> The position of the manual valve is determined solely by which type of input?</p>
+<p><strong>The position of the manual valve is determined solely by which type of input?</p>
 <label><input name="q95" type="radio" value="a"/> Hydraulic pressure from the pump.</label>
 <label><input name="q95" type="radio" value="b"/> The opposing throttle valve pressure.</label>
 <label><input name="q95" type="radio" value="c"/> Mechanical input from the driver (range selector lever).</label>
 <label><input name="q95" type="radio" value="d"/> Electrical input from the Transmission Control Switch (TCS).</label>
 </div>
 <div class="question">
-<p><strong>Question 96:</strong> When pressure builds beyond the tension of the spring in a pressure relief valve, the valve opens and exhausts the excess fluid to which location?</p>
+<p><strong>When pressure builds beyond the tension of the spring in a pressure relief valve, the valve opens and exhausts the excess fluid to which location?</p>
 <label><input name="q96" type="radio" value="a"/> The oil cooler.</label>
 <label><input name="q96" type="radio" value="b"/> The pressure boost chamber.</label>
 <label><input name="q96" type="radio" value="c"/> The sump.</label>
 <label><input name="q96" type="radio" value="d"/> The manual valve inlet port.</label>
 </div>
 <div class="question">
-<p><strong>Question 97:</strong> What is the sole purpose of the Brake Switch signal when received by the PCM?</p>
+<p><strong>What is the sole purpose of the Brake Switch signal when received by the PCM?</p>
 <label><input name="q97" type="radio" value="a"/> To signal the PCM to delay upshifts.</label>
 <label><input name="q97" type="radio" value="b"/> To disengage the torque converter lockup clutch when the brakes are applied.</label>
 <label><input name="q97" type="radio" value="c"/> To increase line pressure for aggressive downshifts.</label>
 <label><input name="q97" type="radio" value="d"/> To automatically engage the park pawl.</label>
 </div>
 <div class="question">
-<p><strong>Question 98:</strong> If the electrical circuit supplying the Electronic Pressure Control (EPC) solenoid fails and the current flow is 0.0 amps, what hydraulic condition results in the transmission?</p>
+<p><strong>If the electrical circuit supplying the Electronic Pressure Control (EPC) solenoid fails and the current flow is 0.0 amps, what hydraulic condition results in the transmission?</p>
 <label><input name="q98" type="radio" value="a"/> The shift solenoids automatically turn on.</label>
 <label><input name="q98" type="radio" value="b"/> Minimum line pressure (0 psi).</label>
 <label><input name="q98" type="radio" value="c"/> Maximum line pressure (the default setting).</label>
 <label><input name="q98" type="radio" value="d"/> Throttle pressure is regulated by the vacuum modulator.</label>
 </div>
 <div class="question">
-<p><strong>Question 99:</strong> Which electronic module provides the necessary vehicle calibration data (based on axle ratio, transmission, tire size, and engine) to the ATCM via the on-vehicle network?</p>
+<p><strong>Which electronic module provides the necessary vehicle calibration data (based on axle ratio, transmission, tire size, and engine) to the ATCM via the on-vehicle network?</p>
 <label><input name="q99" type="radio" value="a"/> Vehicle Speed Sensor (VSS).</label>
 <label><input name="q99" type="radio" value="b"/> Transfer Case Encoder Assembly.</label>
 <label><input name="q99" type="radio" value="c"/> Powertrain Control Module (PCM).</label>
 <label><input name="q99" type="radio" value="d"/> Throttle Position Sensor (TPS).</label>
 </div>
 <div class="question">
-<p><strong>Question 100:</strong> In electronically controlled automatic transmissions, the Vehicle Speed Sensor (VSS) replaces the function of which traditional component used in hydraulically controlled transmissions?</p>
+<p><strong>In electronically controlled automatic transmissions, the Vehicle Speed Sensor (VSS) replaces the function of which traditional component used in hydraulically controlled transmissions?</p>
 <label><input name="q100" type="radio" value="a"/> The vacuum modulator.</label>
 <label><input name="q100" type="radio" value="b"/> The governor.</label>
 <label><input name="q100" type="radio" value="c"/> The manual valve.</label>

--- a/Practice Exam/PTP2_Exam3_270203_Hydraulics_AirBrakes.html
+++ b/Practice Exam/PTP2_Exam3_270203_Hydraulics_AirBrakes.html
@@ -5,6 +5,7 @@
   <title>270203 - Hydraulics, Steering, Suspension and Air Brakes</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="../assets/css/chat.css">
   <!-- Load Firebase config and leaderboard for score submission -->
   <script src="../config/firebase.config.js"></script>
   <script src="../assets/js/leaderboard-firebase.js"></script>
@@ -13,6 +14,8 @@
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
   <script src="../assets/fingerprint-logger.js"></script>
+  <script src="../assets/js/avatar-util.js"></script>
+  <script src="../assets/js/chat.js"></script>
 </head>
 <body>
 
@@ -50,7 +53,7 @@
       </p>
     </section>
 
-    <form id="quiz-form" class="exam-form" data-timer-duration="3000">
+    <form id="quiz-form" class="exam-form">
 
       <div class="question">
         <p><strong>Hydrodynamics in a hydraulic system is best described as:</strong></p>

--- a/Practice Exam/PTP2_Exam4_270204_Electrical_Autobody_Ag_Industrial.html
+++ b/Practice Exam/PTP2_Exam4_270204_Electrical_Autobody_Ag_Industrial.html
@@ -5,6 +5,7 @@
   <title>270204 - Electrical, Autobody, Agricultural and Mobile Industrial Equipment</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="../assets/css/chat.css">
   <!-- Load Firebase config and leaderboard for score submission -->
   <script src="../config/firebase.config.js"></script>
   <script src="../assets/js/leaderboard-firebase.js"></script>
@@ -13,6 +14,8 @@
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
   <script src="../assets/fingerprint-logger.js"></script>
+  <script src="../assets/js/avatar-util.js"></script>
+  <script src="../assets/js/chat.js"></script>
 </head>
 <body>
 
@@ -50,7 +53,7 @@
       </p>
     </section>
 
-    <form id="quiz-form" class="exam-form" data-timer-duration="3000">
+    <form id="quiz-form" class="exam-form">
 
       <div class="question">
         <p><strong>The primary purpose of the charging system on a vehicle or machine is to:</strong></p>

--- a/Practice Exam/index.html
+++ b/Practice Exam/index.html
@@ -40,7 +40,7 @@
 
     <header class="exam-index-header" aria-labelledby="exam-select-heading">
       <h2 id="exam-select-heading">Select a Practice Exam</h2>
-      <p>Each exam contains 100 questions covering all topics in the module. Timer: 50 minutes.</p>
+      <p>Each exam contains 100 questions covering all topics in the module.</p>
     </header>
 
     <section class="exam-grid" aria-label="Available practice exams">

--- a/practice-exams/270201 - Engines and Related Systems Practice Exam.html
+++ b/practice-exams/270201 - Engines and Related Systems Practice Exam.html
@@ -34,9 +34,9 @@
     <div class="back-link"><a href="../index.html">&larr; Back to home</a></div>
     <section class="quiz-page-header">
       <h2>Module 270201 Practice Exam — Engines and Related Systems</h2>
-      <p>100-question practice exam. Timer: 50 minutes (30 seconds per question).</p>
+      <p>100-question practice exam.</p>
     </section>
-    <form id="quiz-form" class="exam-form" data-module="270201" data-exam="practice" data-timer-duration="3000">
+    <form id="quiz-form" class="exam-form" data-module="270201" data-exam="practice">
       <div class="question">
         <p class="question-text"><strong>Question 1:</strong> [Add question text here]</p>
         <div class="answers">

--- a/practice-exams/270202 - Power Train Practice Exam.html
+++ b/practice-exams/270202 - Power Train Practice Exam.html
@@ -48,11 +48,11 @@
     <section class="quiz-page-header">
       <h2>Module 270202 Practice Exam &mdash; Power Train</h2>
       <p>
-        100-question practice exam covering all topics in Power Train. Timer: 50 minutes (30 seconds per question).
+        100-question practice exam covering all topics in Power Train.
       </p>
     </section>
 
-    <form id="quiz-form" class="exam-form" data-module="270202" data-exam="practice" data-timer-duration="3000">
+    <form id="quiz-form" class="exam-form" data-module="270202" data-exam="practice">
 QUESTIONS_PLACEHOLDER
       <div class="exam-actions" id="exam-actions-top">
         <button type="button" id="submit-btn-top" class="btn-submit disabled" disabled>Submit Answers</button>

--- a/practice-exams/270203 - Hydraulics, Steering, Suspension and Air Brakes Practice Exam.html
+++ b/practice-exams/270203 - Hydraulics, Steering, Suspension and Air Brakes Practice Exam.html
@@ -48,11 +48,11 @@
     <section class="quiz-page-header">
       <h2>Module 270203 Practice Exam &mdash; Hydraulics, Steering, Suspension and Air Brakes</h2>
       <p>
-        100-question practice exam covering all topics in Hydraulics, Steering, Suspension and Air Brakes. Timer: 50 minutes (30 seconds per question).
+        100-question practice exam covering all topics in Hydraulics, Steering, Suspension and Air Brakes.
       </p>
     </section>
 
-    <form id="quiz-form" class="exam-form" data-module="270203" data-exam="practice" data-timer-duration="3000">
+    <form id="quiz-form" class="exam-form" data-module="270203" data-exam="practice">
 QUESTIONS_PLACEHOLDER
       <div class="exam-actions" id="exam-actions-top">
         <button type="button" id="submit-btn-top" class="btn-submit disabled" disabled>Submit Answers</button>

--- a/practice-exams/270204 - Electrical, Autobody, Agriculture and Mobile Industrial Equipment Practice Exam.html
+++ b/practice-exams/270204 - Electrical, Autobody, Agriculture and Mobile Industrial Equipment Practice Exam.html
@@ -48,11 +48,11 @@
     <section class="quiz-page-header">
       <h2>Module 270204 Practice Exam &mdash; Electrical, Autobody, Agriculture and Mobile Industrial Equipment</h2>
       <p>
-        100-question practice exam covering all topics in Electrical, Autobody, Agriculture and Mobile Industrial Equipment. Timer: 50 minutes (30 seconds per question).
+        100-question practice exam covering all topics in Electrical, Autobody, Agriculture and Mobile Industrial Equipment.
       </p>
     </section>
 
-    <form id="quiz-form" class="exam-form" data-module="270204" data-exam="practice" data-timer-duration="3000">
+    <form id="quiz-form" class="exam-form" data-module="270204" data-exam="practice">
 QUESTIONS_PLACEHOLDER
       <div class="exam-actions" id="exam-actions-top">
         <button type="button" id="submit-btn-top" class="btn-submit disabled" disabled>Submit Answers</button>


### PR DESCRIPTION
- Removed A./B./C./D. letter prefixes from answers in 270202g-l test files
- Removed "Question #:" format from Practice Exam/PTP2_Exam2_270202
- Added chat.css and chat.js to all 4 Practice Exam pages
- Removed data-timer-duration attribute from all exam HTML files
- Removed "Timer: 50 minutes" text from exam descriptions
- Modified script.js to only show timer when explicitly enabled via data-timer-duration attribute (progress tracker still works)