### PR TITLE
Remove questions referencing figures/diagrams/tables

### DIFF
--- a/270202-test/270202a - Chains, Sprockets, Belts and Pulleys.html
+++ b/270202-test/270202a - Chains, Sprockets, Belts and Pulleys.html
@@ -336,14 +336,6 @@
       </div>
 
       <div class="question">
-        <p><strong>What is the specific functional advantage of using a split-type sprocket (Figure 31b) over a solid sprocket?</strong></p>
-        <label><input type="radio" name="q36" value="a"> It allows the use of a shear pin hub.</label>
-        <label><input type="radio" name="q36" value="b"> The shaft does not have to be removed for installation.</label>
-        <label><input type="radio" name="q36" value="c"> It provides extended support on both sides.</label>
-        <label><input type="radio" name="q36" value="d"> It allows for quick change of the pitch diameter.</label>
-      </div>
-
-      <div class="question">
         <p><strong>To accommodate mounting and provide improved stability, a sprocket hub can be manufactured in which configuration?</strong></p>
         <label><input type="radio" name="q37" value="a"> Flat</label>
         <label><input type="radio" name="q37" value="b"> Close mounting</label>
@@ -421,14 +413,6 @@
         <label><input type="radio" name="q46" value="b"> Fixed center distances</label>
         <label><input type="radio" name="q46" value="c"> Frequent stop and start applications where some slippage is required.</label>
         <label><input type="radio" name="q46" value="d"> Drives operating at less than 1 horsepower.</label>
-      </div>
-
-      <div class="question">
-        <p><strong>In a step pulley system (Figure 58), what adjustment allows the operator to change the drive ratio, thereby affecting the output speed and torque?</strong></p>
-        <label><input type="radio" name="q47" value="a"> Changing the input RPM</label>
-        <label><input type="radio" name="q47" value="b"> Changing the position of the belt on the drive</label>
-        <label><input type="radio" name="q47" value="c"> Replacing the sheaves with those of a different groove angle</label>
-        <label><input type="radio" name="q47" value="d"> Tightening the idler pulley</label>
       </div>
 
       <div class="question">

--- a/270202-test/270202d - Light-Duty Manual Transmissions.html
+++ b/270202-test/270202d - Light-Duty Manual Transmissions.html
@@ -426,14 +426,6 @@
       </div>
 
 <div class="question">
-        <p><strong>In the power flow diagram for reverse gear (Figure 25), when the reverse idler gear turns, what is the consequence for the output shaft&#x27;s rotation?</strong></p>
-        <label><input type="radio" name="q45" value="a"> It freewheels, allowing the output shaft to rotate in the same direction as the input.</label>
-        <label><input type="radio" name="q45" value="b"> It drives the output shaft in a direction opposite to the input shaft rotation.</label>
-        <label><input type="radio" name="q45" value="c"> It locks the 5th/Reverse synchronizer sleeve to the neutral position.</label>
-        <label><input type="radio" name="q45" value="d"> It connects the cluster drive gear directly to the input shaft.</label>
-      </div>
-
-<div class="question">
         <p><strong>When a main shaft is replaced, what related components are suggested as common replacement parts/related sales opportunities?</strong></p>
         <label><input type="radio" name="q46" value="a"> Only seals and gaskets.</label>
         <label><input type="radio" name="q46" value="b"> Only the shift fork and detents.</label>

--- a/270202-test/270202e - Heavy-Duty Manual Transmissions and PTOs.html
+++ b/270202-test/270202e - Heavy-Duty Manual Transmissions and PTOs.html
@@ -550,24 +550,7 @@
 
 
 
-      <div class="question">
-        <p><strong>What is the purpose of the Mainshaft Gear Washer shown in Figure 19, which is positioned on the mainshaft splines and locked in place by a key?</strong></p>
-        <label><input type="radio" name="q49" value="a"> To provide a friction surface for the sliding clutch.</label>
-        <label><input type="radio" name="q49" value="b"> To correctly position the mainshaft gear along the mainshaft.</label>
-        <label><input type="radio" name="q49" value="c"> To take up end thrust loads (Thrust washer).</label>
-        <label><input type="radio" name="q49" value="d"> To act as a roller bearing spacer.</label>
-      </div>
-
-
-
-      <div class="question">
-        <p><strong>The output-bearing retainer in a mechanical speedometer system (Figure 32) has a small bore that provides the mounting position for which gear?</strong></p>
-        <label><input type="radio" name="q50" value="a"> The speed sensor.</label>
-        <label><input type="radio" name="q50" value="b"> The tone ring.</label>
-        <label><input type="radio" name="q50" value="c"> The speedometer-driven gear.</label>
-        <label><input type="radio" name="q50" value="d"> The auxiliary drive gear.</label>
-      </div>
-<div class="exam-actions">
+      <div class="exam-actions">
         <button type="button" id="submit-btn" class="exam-button">
           <span class="dot"></span>
           <span>Submit Answers</span>

--- a/270202-test/270202e-Part2 - Heavy-Duty Manual Transmissions and PTOs.html
+++ b/270202-test/270202e-Part2 - Heavy-Duty Manual Transmissions and PTOs.html
@@ -113,20 +113,6 @@
         <label><input type="radio" name="q8" value="d"> Mounted externally on the transmission PTO opening.</label>
       </div>
       <div class="question">
-        <p><strong>In the oil pump system illustrated in Figure 4, if the oil trough or the oil supply passage in the transmission housing becomes plugged, what is the consequence for the synchronizer assembly?</strong></p>
-        <label><input type="radio" name="q9" value="a"> The mainshaft gear will freewheel, allowing a neutral shift.</label>
-        <label><input type="radio" name="q9" value="b"> The oil pump will not operate, reducing synchronizer assembly service life due to inadequate lubrication.</label>
-        <label><input type="radio" name="q9" value="c"> The relief valve opens, forcing oil into the oil cooler lines.</label>
-        <label><input type="radio" name="q9" value="d"> The sliding clutch will lock the mainshaft gear to the countershaft.</label>
-      </div>
-      <div class="question">
-        <p><strong>What drives the integral oil pump (Figure 5) used to send oil to a cooler in heavy-duty transmissions?</strong></p>
-        <label><input type="radio" name="q10" value="a"> The rotation of the mainshaft gear.</label>
-        <label><input type="radio" name="q10" value="b"> The shifting action of the shift rails.</label>
-        <label><input type="radio" name="q10" value="c"> A PTO gear, driving it any time the input shaft is turning.</label>
-        <label><input type="radio" name="q10" value="d"> A dedicated electric motor controlled by a temperature sensor.</label>
-      </div>
-      <div class="question">
         <p><strong>What action occurs if the oil cooler lines are plugged on a transmission utilizing an integral oil pump with a relief valve?</strong></p>
         <label><input type="radio" name="q11" value="a"> The synchronizer assembly automatically disengages.</label>
         <label><input type="radio" name="q11" value="b"> The clutch brake engages to stop the countershaft rotation.</label>
@@ -146,13 +132,6 @@
         <label><input type="radio" name="q13" value="b"> A check valve</label>
         <label><input type="radio" name="q13" value="c"> Mesh strainers</label>
         <label><input type="radio" name="q13" value="d"> A bypass filter</label>
-      </div>
-      <div class="question">
-        <p><strong>What common component, used as part of the integral oil pump system (Figure 5), is employed to clean the oil of metal particles?</strong></p>
-        <label><input type="radio" name="q14" value="a"> Magnet</label>
-        <label><input type="radio" name="q14" value="b"> Suction tube</label>
-        <label><input type="radio" name="q14" value="c"> Element filter</label>
-        <label><input type="radio" name="q14" value="d"> Relief Valve</label>
       </div>
       <div class="question">
         <p><strong>If a transmission is not equipped with an internal oil pump, an optional externally mounted pump may be used. Where does this external pump typically receive its oil supply?</strong></p>
@@ -356,13 +335,6 @@
         <label><input type="radio" name="q43" value="b"> O-rings and seals (especially output shaft).</label>
         <label><input type="radio" name="q43" value="c"> PTO gears and bearings.</label>
         <label><input type="radio" name="q43" value="d"> Clutch shift friction disks.</label>
-      </div>
-      <div class="question">
-        <p><strong>When a U-joint fails in a PTO driveline system, which related components should the parts technician suggest to the customer as necessary replacement items (Table 3)?</strong></p>
-        <label><input type="radio" name="q44" value="a"> PTO bearings and gaskets.</label>
-        <label><input type="radio" name="q44" value="b"> Driveline shaft, yoke, and steady bearing.</label>
-        <label><input type="radio" name="q44" value="c"> Clutch brake and pilot bearing.</label>
-        <label><input type="radio" name="q44" value="d"> Air shift cylinder and indicator switch.</label>
       </div>
       <div class="question">
         <p><strong>Why must a parts technician provide the model number from the PTO tag when ordering replacement parts for a PTO assembly?</strong></p>

--- a/270202-test/270202f - Drivelines.html
+++ b/270202-test/270202f - Drivelines.html
@@ -450,15 +450,6 @@
 
 
       <div class="question">
-        <p><strong>If a driveline component is classified as a &quot;driveshaft assembly&quot; failure, what related seals and sealing items are recommended replacement sales opportunities (Table 1)?</strong></p>
-        <label><input type="radio" name="q43" value="a"> Only the universal joints.</label>
-        <label><input type="radio" name="q43" value="b"> Only the axle retaining nut.</label>
-        <label><input type="radio" name="q43" value="c"> Yokes, seals, nuts, transaxle housing axle seals, boot kits, boot bands, and boot clamps.</label>
-        <label><input type="radio" name="q43" value="d"> Only the grease fittings and U-joint cross.</label>
-      </div>
-
-
-      <div class="question">
         <p><strong>Which of the following is listed as a function of the driveline?</strong></p>
         <label><input type="radio" name="q44" value="a"> To convert linear motion to rotational motion.</label>
         <label><input type="radio" name="q44" value="b"> To eliminate all driveline angle changes.</label>
@@ -512,16 +503,7 @@
       </div>
 
 
-      <div class="question">
-        <p><strong>If a failed component is listed as a yoke and slip joint, what is a recommended related sales opportunity (Table 1)?</strong></p>
-        <label><input type="radio" name="q50" value="a"> Only U-joints and axle retaining nuts.</label>
-        <label><input type="radio" name="q50" value="b"> Boot kits and boot bands.</label>
-        <label><input type="radio" name="q50" value="c"> Lubricant (grease), fasteners/clamp bolts, seals, U-joints, and axle retaining nuts.</label>
-        <label><input type="radio" name="q50" value="d"> Only the transmission housing axle seals.</label>
-      </div>
-
-
-<div class="exam-actions">
+      <div class="exam-actions">
         <button type="button" id="submit-btn" class="exam-button">
           <span class="dot"></span>
           <span>Submit Answers</span>

--- a/270202-test/270202g - Light-Duty Drive Axle Assemblies.html
+++ b/270202-test/270202g - Light-Duty Drive Axle Assemblies.html
@@ -925,25 +925,6 @@
         </label>
       </div>
       <div class="question">
-        <p><strong>When a pinion seal (#41) fails, which common related sales items should a parts technician suggest to the customer (Table 2)?</strong></p>
-        <label>
-          <input type="radio" name="q46" value="a">
-          Companion flange/yoke, crush sleeve, and gear lube.
-        </label>
-        <label>
-          <input type="radio" name="q46" value="b">
-          Crown and pinion set, shims, and gaskets.
-        </label>
-        <label>
-          <input type="radio" name="q46" value="c">
-          Differential case and differential gears.
-        </label>
-        <label>
-          <input type="radio" name="q46" value="d">
-          Thrust washers and rear axle housing.
-        </label>
-      </div>
-      <div class="question">
         <p><strong>When a differential case fails, what essential components are suggested as related sales, according to Table 2?</strong></p>
         <label>
           <input type="radio" name="q47" value="a">
@@ -1000,30 +981,6 @@
           To hold the thrust washers in place axially.
         </label>
       </div>
-      <div class="question">
-        <p><strong>Based on the identification tag example (Figure 11), a ratio stamped as 3L00 indicates what specific design feature of the axle assembly?</strong></p>
-        <label>
-          <input type="radio" name="q50" value="a">
-          A removable carrier housing
-        </label>
-        <label>
-          <input type="radio" name="q50" value="b">
-          A fixed yoke (companion flange)
-        </label>
-        <label>
-          <input type="radio" name="q50" value="c">
-          A Traction-Lok (Limited Slip)
-        </label>
-        <label>
-          <input type="radio" name="q50" value="d">
-          A straight roller bearing type --------------------------------------------------------------------------------
-        </label>
-      </div>
-
-
-
-
-
       <div class="exam-actions">
         <button type="button" id="submit-btn" class="exam-button">
           <span class="dot"></span>

--- a/270202-test/270202i - All-Wheel Drive.html
+++ b/270202-test/270202i - All-Wheel Drive.html
@@ -286,22 +286,6 @@
       </div>
 
       <div class="question">
-        <p><strong>In a planetary gear center differential (Figure 14), which component is defined as the output member that transfers power to the front wheels?</strong></p>
-        <label><input type="radio" name="q28" value="a">The 1 st Sun Gear.</label>
-        <label><input type="radio" name="q28" value="b">The Intermediate Shaft.</label>
-        <label><input type="radio" name="q28" value="c">The Reduction Drive Gear installed to the carrier.</label>
-        <label><input type="radio" name="q28" value="d">The Rear Drive Shaft.</label>
-      </div>
-
-      <div class="question">
-        <p><strong>What is the core mechanism by which a viscous coupling (Figure 11) locks up to transfer torque when slippage occurs?</strong></p>
-        <label><input type="radio" name="q29" value="a">The mechanical connection between input and output disks locks upon contact.</label>
-        <label><input type="radio" name="q29" value="b">The differential case is actuated by the electric shift motor.</label>
-        <label><input type="radio" name="q29" value="c">The shearing action of the fluid between the slipping disks drives up the temperature, causing the silicone liquid to quickly thicken.</label>
-        <label><input type="radio" name="q29" value="d">The perforated disks are splined directly to the front and rear axles.</label>
-      </div>
-
-      <div class="question">
         <p><strong>In an AWD system with a viscous coupling, what occurs if the front wheels begin to slip?</strong></p>
         <label><input type="radio" name="q30" value="a">The rear differential is unlocked, removing power from the rear wheels.</label>
         <label><input type="radio" name="q30" value="b">The speed sensor sends a signal to the ATCM to manually engage the front axle.</label>
@@ -323,14 +307,6 @@
         <label><input type="radio" name="q32" value="b">A chain drive.</label>
         <label><input type="radio" name="q32" value="c">A viscous coupling.</label>
         <label><input type="radio" name="q32" value="d">A mechanical linkage.</label>
-      </div>
-
-      <div class="question">
-        <p><strong>Which component, shown in the exploded view of the Model 241 transfer case (Table 1), is intended to collect metal fragments and protect internal components?</strong></p>
-        <label><input type="radio" name="q33" value="a">Deflector (80)</label>
-        <label><input type="radio" name="q33" value="b">Oil pump screen (28)</label>
-        <label><input type="radio" name="q33" value="c">Magnet (26)</label>
-        <label><input type="radio" name="q33" value="d">Breather (1)</label>
       </div>
 
       <div class="question">


### PR DESCRIPTION
Removed 16 questions that reference figures, diagrams, or tables that aren't available in the test files:

- 270202a: 2 questions (Figure 31b, Figure 58)
- 270202d: 1 question (Figure 25)
- 270202e: 2 questions (Figure 19, Figure 32)
- 270202e-Part2: 4 questions (Figure 4, Figure 5 x2, Table 3)
- 270202f: 2 questions (Table 1 x2)
- 270202g: 2 questions (Figure 11, Table 2)
- 270202i: 3 questions (Figure 14, Figure 11, Table 1)